### PR TITLE
Add more structs to v1structs, delete contentType

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Authorization: tmpfingerprint: OPENPGP4FPR:AAAABBBBAAAABBBBAAAABBBBAAAABBBBAAAAB
 ```
 {
     "secretUuid": "8ef46a96-f735-11e8-a220-7fd225378c68",
-    "contentType": "text/plain"
 }
 ```
 

--- a/v1structs/structs.go
+++ b/v1structs/structs.go
@@ -1,14 +1,49 @@
 package v1structs
 
+// GetPublicKeyResponse is the JSON structure returned by the get public key
+// API endpoint. See:
+// https://github.com/fluidkeys/api/blob/master/README.md#get-a-public-key
 type GetPublicKeyResponse struct {
+	// ArmoredPublicKey is the ASCII-armored OpenPGP public key.
 	ArmoredPublicKey string `json:"armoredPublicKey"`
 }
 
+// SendSecretRequest is the JSON structure used for requests to the send secret
+// API endpoint. See:
+// https://github.com/fluidkeys/api/blob/master/README.md#send-a-secret-to-a-public-key
 type SendSecretRequest struct {
 	RecipientFingerprint   string `json:"recipientFingerprint"`
 	ArmoredEncryptedSecret string `json:"armoredEncryptedSecret"`
 }
 
+// ListSecretsResponse is the JSON structure returned by the list secrets
+// API endpoint. See:
+// https://github.com/fluidkeys/api/blob/master/README.md#list-your-secrets
+type ListSecretsResponse struct {
+	Secrets []Secret `json:"secrets"`
+}
+
+// Secret is the JSON structure containing the metadata and content for an
+// encrypted secret returned by the list secrets API endpoint.
+type Secret struct {
+	// EncryptedMetadata is an ASCII-armored encrypted PGP message which
+	// decrypts to a `SecretMetadata` JSON structure.
+	EncryptedMetadata string `json:"encryptedMetadata"`
+
+	// EncryptedContent is an ASCII-armored encrypted PGP message
+	// containing the actual content of the secret.
+	EncryptedContent string `json:"encryptedContent"`
+}
+
+// SecretMetadata contains non-content information about an encrypted secret.
+type SecretMetadata struct {
+	// SecretUUID uniquely identifies the secret to the API
+	SecretUUID string `json:"secretUuid"`
+}
+
+// ErrorResponse is the JSON structure returned when the API encounters an
+// error.
 type ErrorResponse struct {
+	// Detail is a human-readable string describing the error.
 	Detail string `json:"detail"`
 }


### PR DESCRIPTION
We don't actually support any `contentType` other than `text/plain` so
don't include it.