### PR TITLE
travis: use postgresql 9.6 from addons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ go:
 addons:
   postgresql: "9.6"
 
-before_install:
-  - go get -u github.com/golang/dep/cmd/dep
-
 script: TEST_DATABASE_URL="postgres://postgres:@localhost:5432/travis" make test
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ go:
   - "1.10.x"
   - master
 
+addons:
+  postgresql: "9.6"
+
 before_install:
   - go get -u github.com/golang/dep/cmd/dep
-
-before_script:
-  - psql -c 'create database travis;' -U postgres
 
 script: TEST_DATABASE_URL="postgres://postgres:@localhost:5432/travis" make test
 


### PR DESCRIPTION
It's not postgres 10 (which we're using on heroku) but it's the nearest I
can get without it being a PITA.

See
https://docs.travis-ci.com/user/database-setup/#using-a-different-postgresql-version

And https://github.com/travis-ci/travis-ci/issues/8537

also, don't install dep (we're not using it)