### PR TITLE
add tests for secret send (and lots of fixes!)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,7 +18,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5dfc68592002e4197766cf3fe8ee6edd5e00493397eddee791da94931465664c"
+  digest = "1:d8b82b337e9f99c31a88b0fec8e8c6de6e6d28859016e88899edb064d5c85d37"
   name = "github.com/fluidkeys/fluidkeys"
   packages = [
     "assert",
@@ -31,7 +31,7 @@
     "policy",
   ]
   pruneopts = "UT"
-  revision = "ab4bdbb1824c349a861e3a61709b279796f655ac"
+  revision = "056465c9909fe3318a93b8a4b283b04ecb194f9b"
 
 [[projects]]
   digest = "1:c594a691090b434d55c67f6cc8e326ef5ba49452abc059821bd5d4fd4cdef08c"

--- a/vendor/github.com/fluidkeys/fluidkeys/fingerprint/fingerprint.go
+++ b/vendor/github.com/fluidkeys/fluidkeys/fingerprint/fingerprint.go
@@ -98,6 +98,15 @@ func (f Fingerprint) Hex() string {
 	return fmt.Sprintf("%0X", b)
 }
 
+// Uri returns the uppercase hex fingerprint prepended with `OPENPGP4FPR:`,
+// as implemented by OpenKeychain:
+// https://github.com/open-keychain/open-keychain/issues/1281#issuecomment-103580789
+// for example:
+// `OPENPGP4FPR:AB01AB01AB01AB01AB01AB01AB01AB01AB01AB01`
+func (f Fingerprint) Uri() string {
+	return fmt.Sprintf("OPENPGP4FPR:%s", f.Hex())
+}
+
 func (f Fingerprint) Bytes() [20]byte {
 	f.assertIsSet()
 	return f.fingerprintBytes


### PR DESCRIPTION
* datastore.CreateSecret: fail nicely if missing fpr
  If there's no key for the given fingerprint, return a nice error rather
  than just giving a foreign key constraint error from postgresql

* bump fluidkeys/fingeprint for Fingerprint.Uri()