### PR TITLE
upsert public key endpoint & tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,13 @@
 
 
 [[projects]]
-  digest = "1:794b0374eaa547e9c375736a05da2a740e695c8816e42d30984228e0c1a5436b"
+  digest = "1:ace3142d1c330736b91b01355276568b90431cedf4d9469798568ef2ba1d64f5"
   name = "github.com/fluidkeys/crypto"
   packages = [
     "cast5",
     "openpgp",
     "openpgp/armor",
+    "openpgp/clearsign",
     "openpgp/elgamal",
     "openpgp/errors",
     "openpgp/packet",
@@ -74,6 +75,8 @@
   input-imports = [
     "github.com/fluidkeys/crypto/openpgp",
     "github.com/fluidkeys/crypto/openpgp/armor",
+    "github.com/fluidkeys/crypto/openpgp/clearsign",
+    "github.com/fluidkeys/crypto/openpgp/packet",
     "github.com/fluidkeys/fluidkeys/assert",
     "github.com/fluidkeys/fluidkeys/exampledata",
     "github.com/fluidkeys/fluidkeys/fingerprint",

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -248,7 +248,7 @@ func VerifySingleUseNumberNotStored(singleUseUUID uuid.UUID) error {
 	}
 
 	if count > 0 {
-		return fmt.Errorf("single use UUID %s already used", singleUseUUID)
+		return fmt.Errorf("single use UUID already used")
 	}
 
 	return nil

--- a/datastore/schema.go
+++ b/datastore/schema.go
@@ -34,4 +34,9 @@ var migrateDatabaseStatements = []string{
 
 	// allow multiple key_id in email_key_link (many email -> 1 key)
 	`ALTER TABLE email_key_link DROP CONSTRAINT IF EXISTS email_key_link_key_id_key`,
+
+	`CREATE TABLE IF NOT EXISTS single_use_uuids (
+                uuid UUID PRIMARY KEY,
+                created_at TIMESTAMP NOT NULL
+    )`,
 }

--- a/server/encrypt.go
+++ b/server/encrypt.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/fluidkeys/crypto/openpgp"
 	"github.com/fluidkeys/crypto/openpgp/armor"
+	"github.com/fluidkeys/crypto/openpgp/clearsign"
 
 	"github.com/fluidkeys/fluidkeys/pgpkey"
 )
@@ -31,4 +33,22 @@ func encryptStringToArmor(secret string, pgpKey *pgpkey.PgpKey) (string, error) 
 	pgpWriteCloser.Close()
 	message.Close()
 	return buffer.String(), nil
+}
+
+func verify(clearsignedData []byte, publicKey *pgpkey.PgpKey) (verifiedPlaintext []byte, err error) {
+	block, _ := clearsign.Decode([]byte(clearsignedData))
+	if block == nil {
+		return nil, fmt.Errorf("error finding clearsigned data")
+	}
+
+	var keyring openpgp.EntityList = []*openpgp.Entity{&publicKey.Entity}
+
+	signer, err := openpgp.CheckDetachedSignature(keyring, bytes.NewBuffer(block.Bytes), block.ArmoredSignature.Body)
+	if err != nil {
+		return nil, fmt.Errorf("signature error: %v", err)
+	} else if signer.PrimaryKey.Fingerprint != publicKey.Entity.PrimaryKey.Fingerprint {
+		return nil, fmt.Errorf("signed by wrong key")
+	}
+
+	return block.Plaintext, nil
 }

--- a/server/json.go
+++ b/server/json.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/fluidkeys/api/v1structs"
 	"log"
 	"net/http"
@@ -32,4 +33,21 @@ func writeJsonError(w http.ResponseWriter, err error, statusCode int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	w.Write(out)
+}
+
+func decodeJsonRequest(r *http.Request, requestData interface{}) error {
+	if r.Header.Get("Content-Type") != "application/json" {
+		return fmt.Errorf("expecting header Content-Type: application/json")
+	}
+
+	if r.Body == nil {
+		return fmt.Errorf("empty request body")
+	}
+
+	decoder := json.NewDecoder(r.Body)
+	err := decoder.Decode(&requestData)
+	if err != nil {
+		return fmt.Errorf("invalid JSON: %v", err)
+	}
+	return nil
 }

--- a/server/keyshandler.go
+++ b/server/keyshandler.go
@@ -1,11 +1,18 @@
 package server
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/fluidkeys/api/datastore"
 	"github.com/fluidkeys/api/v1structs"
+	"github.com/fluidkeys/fluidkeys/pgpkey"
+	"github.com/gofrs/uuid"
 	"github.com/gorilla/mux"
 )
 
@@ -29,4 +36,128 @@ func getPublicKeyHandler(w http.ResponseWriter, r *http.Request) {
 
 	responseData.ArmoredPublicKey = armoredPublicKey
 	writeJsonResponse(w, responseData)
+}
+
+func upsertPublicKeyHandler(w http.ResponseWriter, r *http.Request) {
+	requestData := v1structs.UpsertPublicKeyRequest{}
+
+	if err := decodeJsonRequest(r, &requestData); err != nil {
+		writeJsonError(w, err, http.StatusBadRequest)
+		return
+	}
+
+	publicKey, err := pgpkey.LoadFromArmoredPublicKey(requestData.ArmoredPublicKey)
+	if err != nil {
+		writeJsonError(w, fmt.Errorf("error loading public key: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	singleUseUUID, err := validateSignedData(requestData.ArmoredSignedJSON, requestData.ArmoredPublicKey, publicKey)
+	if err != nil {
+		writeJsonError(w, err, http.StatusBadRequest)
+		return
+	}
+
+	_, encrypted, err := generateAndEncryptPassword(publicKey)
+	if err != nil {
+		writeJsonError(w, err, http.StatusInternalServerError)
+		return
+	}
+
+	err = datastore.UpsertPublicKey(requestData.ArmoredPublicKey)
+	if err != nil {
+		writeJsonError(w, fmt.Errorf("error storing key: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	err = datastore.StoreSingleUseNumber(*singleUseUUID, time.Now())
+	if err != nil {
+		writeJsonError(w, fmt.Errorf("error storing key: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// TODO: store new basic auth password
+
+	responseData := v1structs.UpsertPublicKeyResponse{
+		ArmoredEncryptedBasicAuthPassword: encrypted,
+	}
+
+	writeJsonResponse(w, responseData)
+}
+
+func validateSignedData(armoredSignedData string, armoredPublicKey string, publicKey *pgpkey.PgpKey) (*uuid.UUID, error) {
+	verifiedJSON, err := verify([]byte(armoredSignedData), publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify: %v", err)
+	}
+
+	signedData := v1structs.UpsertPublicKeySignedData{}
+
+	err = json.NewDecoder(bytes.NewReader(verifiedJSON)).Decode(&signedData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode: %v", err)
+	}
+
+	if !within24Hours(time.Now(), signedData.Timestamp) {
+		// TODO: log possible attack
+		return nil, fmt.Errorf("timestamp is not within 24 hours of server time")
+	}
+
+	singleUseUUID, err := uuid.FromString(signedData.SingleUseUUID)
+	if err != nil {
+		return nil, fmt.Errorf("bad SingleUseUUID: %v", err)
+	}
+
+	if err := datastore.VerifySingleUseNumberNotStored(singleUseUUID); err != nil {
+		// TODO: log possible attack
+		return nil, fmt.Errorf("bad SingleUseUUID: %v", err)
+	}
+
+	givenSHA256, err := hex.DecodeString(signedData.PublicKeySHA256)
+	if err != nil {
+		// TODO: log possible attack
+		return nil, fmt.Errorf("bad SHA256: %v", err)
+	}
+
+	calculatedSHA256 := sha256.Sum256([]byte(armoredPublicKey))
+	if !hashesEqual(givenSHA256, calculatedSHA256[:]) {
+		// TODO: log possible attack
+		return nil, fmt.Errorf("mismatching public key SHA256")
+	}
+	return &singleUseUUID, nil
+}
+
+func generateAndEncryptPassword(publicKey *pgpkey.PgpKey) (newPassword string, encrypted string, err error) {
+	if newUUID, err := uuid.NewV4(); err != nil {
+		return "", "", fmt.Errorf("error making UUID: %v", err)
+	} else {
+		newPassword = newUUID.String()
+	}
+
+	encryptedPassword, err := encryptStringToArmor(newPassword, publicKey)
+	if err != nil {
+		return "", "", fmt.Errorf("error encrypting to key: %v", err)
+	}
+	return newPassword, encryptedPassword, nil
+}
+
+func within24Hours(a, b time.Time) bool {
+	const twentyFourHours = time.Hour * time.Duration(24)
+
+	timeDelta := a.Sub(b)
+
+	return -twentyFourHours <= timeDelta && timeDelta < twentyFourHours
+}
+
+func hashesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/server/secretshandler.go
+++ b/server/secretshandler.go
@@ -17,23 +17,10 @@ import (
 )
 
 func sendSecretHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Header.Get("Content-Type") != "application/json" {
-		writeJsonError(w,
-			fmt.Errorf("expecting header Content-Type: application/json"),
-			http.StatusBadRequest)
-		return
-	}
-
-	if r.Body == nil {
-		writeJsonError(w, fmt.Errorf("empty request body"), http.StatusBadRequest)
-		return
-	}
-
-	decoder := json.NewDecoder(r.Body)
 	requestData := v1structs.SendSecretRequest{}
-	err := decoder.Decode(&requestData)
-	if err != nil {
-		writeJsonError(w, fmt.Errorf("invalid JSON: %v", err), http.StatusBadRequest)
+
+	if err := decodeJsonRequest(r, &requestData); err != nil {
+		writeJsonError(w, err, http.StatusBadRequest)
 		return
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -17,7 +17,10 @@ func init() {
 	subrouter = r.PathPrefix("/v1").Subrouter()
 
 	subrouter.HandleFunc("/ping/{word}", pingHandler).Methods("GET")
+
 	subrouter.HandleFunc("/email/{email}/key", getPublicKeyHandler).Methods("GET")
+	subrouter.HandleFunc("/keys", upsertPublicKeyHandler).Methods("POST")
+
 	subrouter.HandleFunc("/secrets", sendSecretHandler).Methods("POST")
 	subrouter.HandleFunc("/secrets", listSecretsHandler).Methods("GET")
 	subrouter.HandleFunc("/secrets/{uuid:"+uuid4Pattern+"}", deleteSecretHandler).Methods("DELETE")

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -669,28 +669,6 @@ func decryptMessage(armoredEncryptedSecret string, key *pgpkey.PgpKey) (io.Reade
 	return decryptedBuf, nil
 }
 
-func sign(bytesToSign []byte, key *pgpkey.PgpKey) (armoredSigned string, err error) {
-	armorOutBuffer := bytes.NewBuffer(nil)
-	armorWriteCloser, err := armor.Encode(armorOutBuffer, "PGP SIGNED MESSAGE", nil)
-	if err != nil {
-		return "", err
-	}
-
-	signWriteCloser, err := openpgp.Sign(armorWriteCloser, &key.Entity, nil, nil)
-	if err != nil {
-		return "", err
-	}
-
-	_, err = signWriteCloser.Write(bytesToSign)
-	if err != nil {
-		return "", err
-	}
-
-	signWriteCloser.Close()
-	armorWriteCloser.Close()
-	return armorOutBuffer.String(), nil
-}
-
 func signText(bytesToSign []byte, key *pgpkey.PgpKey) (armoredSigned string, err error) {
 	armorOutBuffer := bytes.NewBuffer(nil)
 	privKey := key.Entity.PrivateKey

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -102,8 +102,16 @@ func TestGetPublicKeyHandler(t *testing.T) {
 }
 
 func TestUpsertPublicKeyHandler(t *testing.T) {
+	armoredPublicKey := exampledata.ExamplePublicKey4
+	validSha256 := fmt.Sprintf("%X", sha256.Sum256([]byte(exampledata.ExamplePublicKey4)))
+	publicKey, err := pgpkey.LoadFromArmoredPublicKey(armoredPublicKey)
+	assert.ErrorIsNil(t, err)
+
 	unlockedKey, err := pgpkey.LoadFromArmoredEncryptedPrivateKey(exampledata.ExamplePrivateKey4, "test4")
 	assert.ErrorIsNil(t, err)
+
+	uuid1 := uuid.Must(uuid.NewV4())
+	now := time.Date(2018, 6, 15, 16, 30, 0, 0, time.UTC)
 
 	setup := func() {
 
@@ -114,32 +122,103 @@ func TestUpsertPublicKeyHandler(t *testing.T) {
 		assert.ErrorIsNil(t, err)
 	}
 
-	setup()
-
-	// TODO: content header tests etc
-
-	t.Run("valid signed data, brand new key", func(t *testing.T) {
-
+	makeSignedData := func(t *testing.T, timestamp time.Time, uuidString string, sha256 string) string {
+		t.Helper()
 		upsertPublicKeyJSON := new(bytes.Buffer)
 
 		err := json.NewEncoder(upsertPublicKeyJSON).Encode(
 			v1structs.UpsertPublicKeySignedData{
-				Timestamp:       time.Now(),
-				SingleUseUUID:   uuid.Must(uuid.NewV4()).String(),
-				PublicKeySHA256: fmt.Sprintf("%X", sha256.Sum256([]byte(exampledata.ExamplePublicKey4))),
+				Timestamp:       timestamp,
+				SingleUseUUID:   uuidString,
+				PublicKeySHA256: sha256,
 			})
 		assert.ErrorIsNil(t, err)
 
+		signedData, err := signText(upsertPublicKeyJSON.Bytes(), unlockedKey)
+		assert.ErrorIsNil(t, err)
+		return signedData
+	}
+
+	setup()
+
+	// TODO: content header tests etc
+
+	t.Run("bad (truncated) signature", func(t *testing.T) {
+		goodSig := makeSignedData(t, now, uuid1.String(), validSha256)
+
+		truncatedSignature := goodSig[0 : len(goodSig)/2]
+
+		_, err := validateSignedData(truncatedSignature, armoredPublicKey, publicKey, now)
+		assert.Equal(t, "failed to verify: error finding clearsigned data", err.Error())
+	})
+
+	t.Run("mismatching SHA256", func(t *testing.T) {
+		armoredSignedData := makeSignedData(t, now, uuid1.String(), "0a0a")
+		_, err := validateSignedData(armoredSignedData, armoredPublicKey, publicKey, now)
+		assert.Equal(t, "mismatching public key SHA256", err.Error())
+	})
+
+	t.Run("timestamp too far in the future", func(t *testing.T) {
+		thirtyHoursFromNow := now.Add(time.Hour * time.Duration(30))
+		armoredSignedData := makeSignedData(t, thirtyHoursFromNow, uuid1.String(), validSha256)
+
+		_, err := validateSignedData(armoredSignedData, armoredPublicKey, publicKey, now)
+		assert.Equal(t, "timestamp is not within 24 hours of server time", err.Error())
+	})
+
+	t.Run("timestamp too far in the past", func(t *testing.T) {
+		thirtyHoursInPast := now.Add(time.Hour * time.Duration(-30))
+		armoredSignedData := makeSignedData(t, thirtyHoursInPast, uuid1.String(), validSha256)
+
+		_, err := validateSignedData(armoredSignedData, armoredPublicKey, publicKey, now)
+		assert.Equal(t, "timestamp is not within 24 hours of server time", err.Error())
+	})
+
+	t.Run("single use UUID not a valid UUID", func(t *testing.T) {
+		armoredSignedData := makeSignedData(t, now, "foo", validSha256)
+
+		_, err := validateSignedData(armoredSignedData, armoredPublicKey, publicKey, now)
+		assert.Equal(t, "bad SingleUseUUID: uuid: incorrect UUID length: foo", err.Error())
+	})
+
+	t.Run("single use UUID already used", func(t *testing.T) {
+		repeatedUUID := uuid.Must(uuid.NewV4())
+
+		datastore.StoreSingleUseNumber(repeatedUUID, now)
+
+		armoredSignedData := makeSignedData(t, now, repeatedUUID.String(), validSha256)
+
+		_, err := validateSignedData(armoredSignedData, armoredPublicKey, publicKey, now)
+		assert.Equal(t, "bad SingleUseUUID: single use UUID already used", err.Error())
+	})
+
+	t.Run("valid signed data, brand new key", func(t *testing.T) {
+
 		requestData := v1structs.UpsertPublicKeyRequest{
 			ArmoredPublicKey: exampledata.ExamplePublicKey4,
+			ArmoredSignedJSON: makeSignedData(
+				t,
+				time.Now(),
+				uuid.Must(uuid.NewV4()).String(),
+				validSha256),
 		}
 
-		requestData.ArmoredSignedJSON, err = signText(upsertPublicKeyJSON.Bytes(), unlockedKey)
+		response := callApiWithJson(t, "POST", "/v1/keys", requestData)
+		fmt.Print(response.Body)
+		assertStatusCode(t, http.StatusOK, response.Code)
+
+		responseData := v1structs.UpsertPublicKeyResponse{}
+		err = json.NewDecoder(response.Body).Decode(&responseData)
 		assert.ErrorIsNil(t, err)
 
-		response := callApiWithJson(t, "POST", "/v1/keys", requestData)
-		assertStatusCode(t, http.StatusOK, response.Code)
-		fmt.Print(response.Body)
+		newPasswordReader, err := decryptMessage(responseData.ArmoredEncryptedBasicAuthPassword, unlockedKey)
+		assert.ErrorIsNil(t, err)
+
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(newPasswordReader)
+
+		_, err = uuid.FromString(buf.String())
+		assert.ErrorIsNil(t, err)
 	})
 
 	teardown()

--- a/vendor/github.com/fluidkeys/crypto/openpgp/clearsign/clearsign.go
+++ b/vendor/github.com/fluidkeys/crypto/openpgp/clearsign/clearsign.go
@@ -1,0 +1,399 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package clearsign generates and processes OpenPGP, clear-signed data. See
+// RFC 4880, section 7.
+//
+// Clearsigned messages are cryptographically signed, but the contents of the
+// message are kept in plaintext so that it can be read without special tools.
+package clearsign // import "github.com/fluidkeys/crypto/openpgp/clearsign"
+
+import (
+	"bufio"
+	"bytes"
+	"crypto"
+	"fmt"
+	"hash"
+	"io"
+	"net/textproto"
+	"strconv"
+
+	"github.com/fluidkeys/crypto/openpgp/armor"
+	"github.com/fluidkeys/crypto/openpgp/errors"
+	"github.com/fluidkeys/crypto/openpgp/packet"
+)
+
+// A Block represents a clearsigned message. A signature on a Block can
+// be checked by passing Bytes into openpgp.CheckDetachedSignature.
+type Block struct {
+	Headers          textproto.MIMEHeader // Optional message headers
+	Plaintext        []byte               // The original message text
+	Bytes            []byte               // The signed message
+	ArmoredSignature *armor.Block         // The signature block
+}
+
+// start is the marker which denotes the beginning of a clearsigned message.
+var start = []byte("\n-----BEGIN PGP SIGNED MESSAGE-----")
+
+// dashEscape is prefixed to any lines that begin with a hyphen so that they
+// can't be confused with endText.
+var dashEscape = []byte("- ")
+
+// endText is a marker which denotes the end of the message and the start of
+// an armored signature.
+var endText = []byte("-----BEGIN PGP SIGNATURE-----")
+
+// end is a marker which denotes the end of the armored signature.
+var end = []byte("\n-----END PGP SIGNATURE-----")
+
+var crlf = []byte("\r\n")
+var lf = byte('\n')
+
+// getLine returns the first \r\n or \n delineated line from the given byte
+// array. The line does not include the \r\n or \n. The remainder of the byte
+// array (also not including the new line bytes) is also returned and this will
+// always be smaller than the original argument.
+func getLine(data []byte) (line, rest []byte) {
+	i := bytes.Index(data, []byte{'\n'})
+	var j int
+	if i < 0 {
+		i = len(data)
+		j = i
+	} else {
+		j = i + 1
+		if i > 0 && data[i-1] == '\r' {
+			i--
+		}
+	}
+	return data[0:i], data[j:]
+}
+
+// Decode finds the first clearsigned message in data and returns it, as well
+// as the suffix of data which remains after the message.
+func Decode(data []byte) (b *Block, rest []byte) {
+	// start begins with a newline. However, at the very beginning of
+	// the byte array, we'll accept the start string without it.
+	rest = data
+	if bytes.HasPrefix(data, start[1:]) {
+		rest = rest[len(start)-1:]
+	} else if i := bytes.Index(data, start); i >= 0 {
+		rest = rest[i+len(start):]
+	} else {
+		return nil, data
+	}
+
+	// Consume the start line.
+	_, rest = getLine(rest)
+
+	var line []byte
+	b = &Block{
+		Headers: make(textproto.MIMEHeader),
+	}
+
+	// Next come a series of header lines.
+	for {
+		// This loop terminates because getLine's second result is
+		// always smaller than its argument.
+		if len(rest) == 0 {
+			return nil, data
+		}
+		// An empty line marks the end of the headers.
+		if line, rest = getLine(rest); len(line) == 0 {
+			break
+		}
+
+		i := bytes.Index(line, []byte{':'})
+		if i == -1 {
+			return nil, data
+		}
+
+		key, val := line[0:i], line[i+1:]
+		key = bytes.TrimSpace(key)
+		val = bytes.TrimSpace(val)
+		b.Headers.Add(string(key), string(val))
+	}
+
+	firstLine := true
+	for {
+		start := rest
+
+		line, rest = getLine(rest)
+		if len(line) == 0 && len(rest) == 0 {
+			// No armored data was found, so this isn't a complete message.
+			return nil, data
+		}
+		if bytes.Equal(line, endText) {
+			// Back up to the start of the line because armor expects to see the
+			// header line.
+			rest = start
+			break
+		}
+
+		// The final CRLF isn't included in the hash so we don't write it until
+		// we've seen the next line.
+		if firstLine {
+			firstLine = false
+		} else {
+			b.Bytes = append(b.Bytes, crlf...)
+		}
+
+		if bytes.HasPrefix(line, dashEscape) {
+			line = line[2:]
+		}
+		line = bytes.TrimRight(line, " \t")
+		b.Bytes = append(b.Bytes, line...)
+
+		b.Plaintext = append(b.Plaintext, line...)
+		b.Plaintext = append(b.Plaintext, lf)
+	}
+
+	// We want to find the extent of the armored data (including any newlines at
+	// the end).
+	i := bytes.Index(rest, end)
+	if i == -1 {
+		return nil, data
+	}
+	i += len(end)
+	for i < len(rest) && (rest[i] == '\r' || rest[i] == '\n') {
+		i++
+	}
+	armored := rest[:i]
+	rest = rest[i:]
+
+	var err error
+	b.ArmoredSignature, err = armor.Decode(bytes.NewBuffer(armored))
+	if err != nil {
+		return nil, data
+	}
+
+	return b, rest
+}
+
+// A dashEscaper is an io.WriteCloser which processes the body of a clear-signed
+// message. The clear-signed message is written to buffered and a hash, suitable
+// for signing, is maintained in h.
+//
+// When closed, an armored signature is created and written to complete the
+// message.
+type dashEscaper struct {
+	buffered *bufio.Writer
+	hashers  []hash.Hash // one per key in privateKeys
+	hashType crypto.Hash
+	toHash   io.Writer // writes to all the hashes in hashers
+
+	atBeginningOfLine bool
+	isFirstLine       bool
+
+	whitespace []byte
+	byteBuf    []byte // a one byte buffer to save allocations
+
+	privateKeys []*packet.PrivateKey
+	config      *packet.Config
+}
+
+func (d *dashEscaper) Write(data []byte) (n int, err error) {
+	for _, b := range data {
+		d.byteBuf[0] = b
+
+		if d.atBeginningOfLine {
+			// The final CRLF isn't included in the hash so we have to wait
+			// until this point (the start of the next line) before writing it.
+			if !d.isFirstLine {
+				d.toHash.Write(crlf)
+			}
+			d.isFirstLine = false
+		}
+
+		// Any whitespace at the end of the line has to be removed so we
+		// buffer it until we find out whether there's more on this line.
+		if b == ' ' || b == '\t' || b == '\r' {
+			d.whitespace = append(d.whitespace, b)
+			d.atBeginningOfLine = false
+			continue
+		}
+
+		if d.atBeginningOfLine {
+			// At the beginning of a line, hyphens have to be escaped.
+			if b == '-' {
+				// The signature isn't calculated over the dash-escaped text so
+				// the escape is only written to buffered.
+				if _, err = d.buffered.Write(dashEscape); err != nil {
+					return
+				}
+				d.toHash.Write(d.byteBuf)
+				d.atBeginningOfLine = false
+			} else if b == '\n' {
+				// Nothing to do because we delay writing CRLF to the hash.
+			} else {
+				d.toHash.Write(d.byteBuf)
+				d.atBeginningOfLine = false
+			}
+			if err = d.buffered.WriteByte(b); err != nil {
+				return
+			}
+		} else {
+			if b == '\n' {
+				// We got a raw \n. Drop any trailing whitespace and write a
+				// CRLF.
+				d.whitespace = d.whitespace[:0]
+				// We delay writing CRLF to the hash until the start of the
+				// next line.
+				if err = d.buffered.WriteByte(b); err != nil {
+					return
+				}
+				d.atBeginningOfLine = true
+			} else {
+				// Any buffered whitespace wasn't at the end of the line so
+				// we need to write it out.
+				if len(d.whitespace) > 0 {
+					d.toHash.Write(d.whitespace)
+					if _, err = d.buffered.Write(d.whitespace); err != nil {
+						return
+					}
+					d.whitespace = d.whitespace[:0]
+				}
+				d.toHash.Write(d.byteBuf)
+				if err = d.buffered.WriteByte(b); err != nil {
+					return
+				}
+			}
+		}
+	}
+
+	n = len(data)
+	return
+}
+
+func (d *dashEscaper) Close() (err error) {
+	if !d.atBeginningOfLine {
+		if err = d.buffered.WriteByte(lf); err != nil {
+			return
+		}
+	}
+
+	out, err := armor.Encode(d.buffered, "PGP SIGNATURE", nil)
+	if err != nil {
+		return
+	}
+
+	t := d.config.Now()
+	for i, k := range d.privateKeys {
+		sig := new(packet.Signature)
+		sig.SigType = packet.SigTypeText
+		sig.PubKeyAlgo = k.PubKeyAlgo
+		sig.Hash = d.hashType
+		sig.CreationTime = t
+		sig.IssuerKeyId = &k.KeyId
+
+		if err = sig.Sign(d.hashers[i], k, d.config); err != nil {
+			return
+		}
+		if err = sig.Serialize(out); err != nil {
+			return
+		}
+	}
+
+	if err = out.Close(); err != nil {
+		return
+	}
+	if err = d.buffered.Flush(); err != nil {
+		return
+	}
+	return
+}
+
+// Encode returns a WriteCloser which will clear-sign a message with privateKey
+// and write it to w. If config is nil, sensible defaults are used.
+func Encode(w io.Writer, privateKey *packet.PrivateKey, config *packet.Config) (plaintext io.WriteCloser, err error) {
+	return EncodeMulti(w, []*packet.PrivateKey{privateKey}, config)
+}
+
+// EncodeMulti returns a WriteCloser which will clear-sign a message with all the
+// private keys indicated and write it to w. If config is nil, sensible defaults
+// are used.
+func EncodeMulti(w io.Writer, privateKeys []*packet.PrivateKey, config *packet.Config) (plaintext io.WriteCloser, err error) {
+	for _, k := range privateKeys {
+		if k.Encrypted {
+			return nil, errors.InvalidArgumentError(fmt.Sprintf("signing key %s is encrypted", k.KeyIdString()))
+		}
+	}
+
+	hashType := config.Hash()
+	name := nameOfHash(hashType)
+	if len(name) == 0 {
+		return nil, errors.UnsupportedError("unknown hash type: " + strconv.Itoa(int(hashType)))
+	}
+
+	if !hashType.Available() {
+		return nil, errors.UnsupportedError("unsupported hash type: " + strconv.Itoa(int(hashType)))
+	}
+	var hashers []hash.Hash
+	var ws []io.Writer
+	for range privateKeys {
+		h := hashType.New()
+		hashers = append(hashers, h)
+		ws = append(ws, h)
+	}
+	toHash := io.MultiWriter(ws...)
+
+	buffered := bufio.NewWriter(w)
+	// start has a \n at the beginning that we don't want here.
+	if _, err = buffered.Write(start[1:]); err != nil {
+		return
+	}
+	if err = buffered.WriteByte(lf); err != nil {
+		return
+	}
+	if _, err = buffered.WriteString("Hash: "); err != nil {
+		return
+	}
+	if _, err = buffered.WriteString(name); err != nil {
+		return
+	}
+	if err = buffered.WriteByte(lf); err != nil {
+		return
+	}
+	if err = buffered.WriteByte(lf); err != nil {
+		return
+	}
+
+	plaintext = &dashEscaper{
+		buffered: buffered,
+		hashers:  hashers,
+		hashType: hashType,
+		toHash:   toHash,
+
+		atBeginningOfLine: true,
+		isFirstLine:       true,
+
+		byteBuf: make([]byte, 1),
+
+		privateKeys: privateKeys,
+		config:      config,
+	}
+
+	return
+}
+
+// nameOfHash returns the OpenPGP name for the given hash, or the empty string
+// if the name isn't known. See RFC 4880, section 9.4.
+func nameOfHash(h crypto.Hash) string {
+	switch h {
+	case crypto.MD5:
+		return "MD5"
+	case crypto.SHA1:
+		return "SHA1"
+	case crypto.RIPEMD160:
+		return "RIPEMD160"
+	case crypto.SHA224:
+		return "SHA224"
+	case crypto.SHA256:
+		return "SHA256"
+	case crypto.SHA384:
+		return "SHA384"
+	case crypto.SHA512:
+		return "SHA512"
+	}
+	return ""
+}


### PR DESCRIPTION
* update v1structs for upsert public key endpoint
* verify(..) function for clearsigned data
* factor out decodeJsonRequest function
* add datastore single use UUID table & funcs
* add github.com/fluidkeys/crypto/openpgp/clearsign