### PR TITLE
Send verification emails on public key upsert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ script: TEST_DATABASE_URL="postgres://postgres:@localhost:5432/travis" make test
 
 notifications:
     email: false
+
+env:
+  global:
+    - DISABLE_SEND_EMAIL=1

--- a/email/email.go
+++ b/email/email.go
@@ -286,7 +286,7 @@ type verifyEmail struct {
 // funcMap defines template functions that transform variables into strings in the template
 var funcMap = template.FuncMap{
 	"FormatDateTime": func(t time.Time) string {
-		return t.Format("15:04:05 MST on 02 January 2006")
+		return t.Format("15:04:05 MST on 2 January 2006")
 	},
 	"FormatDate": func(t time.Time) string {
 		return t.Format("2 January 2006")

--- a/email/email.go
+++ b/email/email.go
@@ -157,7 +157,7 @@ func shouldSendVerificationEmail(txn *sql.Tx, email string) (bool, error) {
 }
 
 func makeVerificationUrl(secretUUID uuid.UUID) string {
-	return fmt.Sprintf("https://api.fluidkeys.com/v1/emails/verify/%s", secretUUID.String())
+	return fmt.Sprintf("https://api.fluidkeys.com/v1/email/verify/%s", secretUUID.String())
 }
 
 type email struct {

--- a/email/email.go
+++ b/email/email.go
@@ -209,7 +209,7 @@ func (e *email) send() error {
 	}
 
 	if e.subject == "" {
-		return fmt.Errorf("empty HTML body")
+		return fmt.Errorf("empty subject")
 	}
 
 	from, err := mail.ParseAddress(e.from) // validate from address

--- a/email/email.go
+++ b/email/email.go
@@ -296,16 +296,37 @@ var funcMap = template.FuncMap{
 }
 
 const verifySubjectTemplate = "Verify {{.Email}} on Fluidkeys"
-const verifyHtmlBodyTemplate string = `Verify your email address to allow others to find your PGP key and send you encrypted secrets.
+const verifyHtmlBodyTemplate string = `<!DOCTYPE HTML>
 
-Click this link to verify your key now:
+<html>
+<body>
+<p>
+Verify your email address to allow others to find your PGP key and send you encrypted secrets.
+</p>
 
-<a href="{{.VerificationUrl}}">Verify {{.Email}} and allow others to find your PGP key</a>
+<p>
+<a href="{{.VerificationUrl}}">Verify {{.Email}}</a>
+</p>
 
----
+<p>
+If clicking the link above doesn't work, copy and paste this link into your browser:
+</p>
 
-You're receiving this email because a PGP public key was uploaded to Fluidkeys from {{.RequestIpAddress}} at {{.RequestTime|FormatDateTime}}.
+<p>
+<a href="{{.VerificationUrl}}">{{.VerificationUrl}}</a>
+</p>
 
+<hr>
+<p>
+You're receiving this email because a PGP public key was uploaded to <a href="https://www.fluidkeys.com">Fluidkeys</a> from {{.RequestIpAddress}} at {{.RequestTime|FormatDateTime}}.
+
+<p>
 Key {{.KeyFingerprint}} created {{.KeyCreatedDate|FormatDate}}
+</p>
 
-If you aren't expecting this email, please reply to this email so we can investigate.`
+<p>
+If you aren't expecting this email, please reply to this email so we can investigate.
+</p>
+
+</body>
+</html>`

--- a/email/email.go
+++ b/email/email.go
@@ -1,0 +1,309 @@
+package email
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"html/template"
+	"log"
+	"net/mail"
+	"net/smtp"
+	"net/textproto"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/fluidkeys/api/datastore"
+	"github.com/fluidkeys/fluidkeys/pgpkey"
+	"github.com/gofrs/uuid"
+)
+
+func init() {
+	if os.Getenv("DISABLE_SEND_EMAIL") == "1" {
+		disableSendEmail = true
+		return
+	}
+
+	var got = false
+	smtpHost, got = os.LookupEnv("SMTP_HOST")
+	if !got {
+		log.Panic("SMTP_HOST not set (set DISABLE_SEND_EMAIL=1 to disable)")
+	}
+
+	smtpPort, got = os.LookupEnv("SMTP_PORT")
+	if !got {
+		log.Panic("SMTP_PORT not set (set DISABLE_SEND_EMAIL=1 to disable)")
+	}
+
+	port, err := strconv.Atoi(smtpPort)
+	if err != nil || port < 0 || port > 65535 {
+		log.Panicf("invalid SMTP_PORT '%d', should be an integer in range 1-65535", port)
+	}
+
+	smtpUsername, got = os.LookupEnv("SMTP_USERNAME")
+	if !got {
+		log.Panic("SMTP_USERNAME not set (set DISABLE_SEND_EMAIL=1 to disable)")
+	}
+
+	smtpPassword, got = os.LookupEnv("SMTP_PASSWORD")
+	if !got {
+		log.Panic("SMTP_PASSWORD not set (set DISABLE_SEND_EMAIL=1 to disable)")
+	}
+}
+
+type VerificationMetadata struct {
+	RequestUserAgent string
+	RequestIpAddress string
+	RequestTime      time.Time
+}
+
+// SendVerificationEmails iterates through the email addresses on the given key and works out
+// whether to send each one a verification email.
+// If so, it renders and sends the verification email, and records a new verification in the
+// database.
+func SendVerificationEmails(
+	txn *sql.Tx, publicKey *pgpkey.PgpKey, meta VerificationMetadata) error {
+
+	for _, email := range publicKey.Emails(true) {
+		shouldSend, err := shouldSendVerificationEmail(txn, email)
+		if err != nil {
+			return err
+		} else if shouldSend {
+			if err := sendVerificationEmail(txn, email, publicKey, meta); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func sendVerificationEmail(
+	txn *sql.Tx, emailAddress string, publicKey *pgpkey.PgpKey,
+	meta VerificationMetadata) error {
+
+	verifySecretUUID, err := datastore.CreateVerification(
+		txn, emailAddress, publicKey.Fingerprint(),
+		meta.RequestUserAgent,
+		meta.RequestIpAddress,
+		meta.RequestTime,
+	)
+	if err != nil {
+		return err
+	}
+
+	emailTemplateData := verifyEmail{
+		Email:            emailAddress,
+		VerificationUrl:  makeVerificationUrl(*verifySecretUUID),
+		RequestIpAddress: meta.RequestIpAddress,
+		RequestTime:      meta.RequestTime,
+		KeyFingerprint:   publicKey.Fingerprint().Hex(),
+		KeyCreatedDate:   publicKey.PrimaryKey.CreationTime,
+	}
+
+	email := email{
+		to:      emailAddress,
+		from:    "Fluidkeys <verify@mail.fluidkeys.com>",
+		replyTo: "Fluidkeys Security <security@fluidkeys.com>",
+		bcc:     "hello@fluidkeys.com",
+	}
+
+	if err := email.renderSubjectAndBody(emailTemplateData); err != nil {
+		return fmt.Errorf("error rendering email: %v", err)
+	}
+
+	log.Printf("email.htmlBody: %s\n", email.htmlBody)
+
+	if err := email.send(); err != nil {
+		return fmt.Errorf("error sending mail: %v", err)
+	}
+	return nil
+}
+
+// shouldSendVerificationEmail returns true if an email address should receive a new verification
+// email
+func shouldSendVerificationEmail(txn *sql.Tx, email string) (bool, error) {
+	_, alreadyLinked, err := datastore.GetArmoredPublicKeyForEmail(email)
+	if err != nil {
+		return false, err
+	}
+	if alreadyLinked {
+		// 1. it's linked to the same key, in which case there's
+		//    nothing to do
+		// 2. it's linked to one key, and this is a request
+		//    to link the email to a *different* key, which we don't
+		//    currently allow. The email_key_link must be deleted
+		//    before the email can be linked again. Note that this
+		//    happens if the whole linked *key* is deleted.
+		return false, nil
+	}
+
+	hasActiveVerification, err := datastore.HasActiveVerificationForEmail(txn, email)
+	if err != nil {
+		return false, err
+	}
+	if hasActiveVerification {
+		// prevents an attacker from mailbombing an email address by
+		// creating lots of different keys with the email: if there's
+		// an active email verification, it has to expire before
+		// another one can be created
+		log.Printf("email verification already exists for %s, not sending another", email)
+		return false, nil
+	}
+
+	log.Printf("no currently-active verifications for email '%s'", email)
+
+	return true, nil
+}
+
+func makeVerificationUrl(secretUUID uuid.UUID) string {
+	return fmt.Sprintf("https://api.fluidkeys.com/v1/emails/verify/%s", secretUUID.String())
+}
+
+type email struct {
+	to       string
+	from     string
+	replyTo  string
+	bcc      string
+	subject  string
+	htmlBody string
+}
+
+func inferTemplateName(emailTemplateData interface{}) (string, error) {
+	switch emailTemplateData.(type) {
+	case verifyEmail:
+		return "verify", nil
+	}
+
+	return "", fmt.Errorf("failed to get template name from data: %v", emailTemplateData)
+}
+
+func (e *email) renderSubjectAndBody(data interface{}) (err error) {
+	templateName, err := inferTemplateName(data)
+	if err != nil {
+		return err
+	}
+
+	switch templateName {
+	case "verify":
+		e.subject, err = render(verifySubjectTemplate, data)
+		if err != nil {
+			return err
+		}
+
+		e.htmlBody, err = render(verifyHtmlBodyTemplate, data)
+		if err != nil {
+			return err
+		}
+
+	default:
+		return fmt.Errorf("unknown template: %s", templateName)
+	}
+
+	return nil
+}
+
+func (e *email) send() error {
+
+	if e.htmlBody == "" {
+		return fmt.Errorf("empty HTML body")
+	}
+
+	if e.subject == "" {
+		return fmt.Errorf("empty HTML body")
+	}
+
+	from, err := mail.ParseAddress(e.from) // validate from address
+	if err != nil {
+		return fmt.Errorf("error parsing address: %v", err)
+	}
+
+	to, err := mail.ParseAddress(e.to) // validate to address
+	if err != nil {
+		return fmt.Errorf("error parsing to address: %v", err)
+	}
+
+	header := textproto.MIMEHeader{}
+	header.Set(textproto.CanonicalMIMEHeaderKey("from"), e.from)
+	header.Set(textproto.CanonicalMIMEHeaderKey("to"), e.to)
+	header.Set(textproto.CanonicalMIMEHeaderKey("reply-to"), e.replyTo)
+	header.Set(textproto.CanonicalMIMEHeaderKey("content-type"), "text/html; charset=UTF-8")
+	header.Set(textproto.CanonicalMIMEHeaderKey("mime-version"), "1.0")
+	header.Set(textproto.CanonicalMIMEHeaderKey("subject"), e.subject)
+
+	var buffer bytes.Buffer
+
+	// write header
+	for key, value := range header {
+		buffer.WriteString(fmt.Sprintf("%s: %s\r\n", key, value[0]))
+	}
+
+	// write body
+	buffer.WriteString(fmt.Sprintf("\r\n%s", e.htmlBody))
+
+	if disableSendEmail {
+		fmt.Printf("DISABLE_SEND_EMAIL=1, email:\n----\n%s\n----\n", buffer.String())
+		return nil
+	} else {
+		addr := fmt.Sprintf("%s:%s", smtpHost, smtpPort)
+		auth := smtp.PlainAuth("", smtpUsername, smtpPassword, smtpHost)
+		return smtp.SendMail(addr, auth, from.Address, []string{to.Address}, buffer.Bytes())
+	}
+}
+
+func render(templateText string, emailTemplateData interface{}) (string, error) {
+
+	t, err := template.New("").Funcs(funcMap).Parse(templateText)
+
+	if err != nil {
+		return "", err
+	}
+	buf := bytes.NewBuffer(nil)
+	err = t.Execute(buf, emailTemplateData)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+var (
+	disableSendEmail bool
+	smtpHost         string
+	smtpPort         string
+	smtpUsername     string
+	smtpPassword     string
+)
+
+// verifyEmail holds the data required to populate the "verify" email templates
+type verifyEmail struct {
+	Email            string
+	VerificationUrl  string
+	RequestIpAddress string
+	RequestTime      time.Time
+	KeyFingerprint   string
+	KeyCreatedDate   time.Time
+}
+
+// funcMap defines template functions that transform variables into strings in the template
+var funcMap = template.FuncMap{
+	"FormatDateTime": func(t time.Time) string {
+		return t.Format("15:04:05 MST on 02 January 2006")
+	},
+	"FormatDate": func(t time.Time) string {
+		return t.Format("2 January 2006")
+	},
+}
+
+const verifySubjectTemplate = "Verify {{.Email}} on Fluidkeys"
+const verifyHtmlBodyTemplate string = `Verify your email address to allow others to find your PGP key and send you encrypted secrets.
+
+Click this link to verify your key now:
+
+<a href="{{.VerificationUrl}}">Verify {{.Email}} and allow others to find your PGP key</a>
+
+---
+
+You're receiving this email because a PGP public key was uploaded to Fluidkeys from {{.RequestIpAddress}} at {{.RequestTime|FormatDateTime}}.
+
+Key {{.KeyFingerprint}} created {{.KeyCreatedDate|FormatDate}}
+
+If you aren't expecting this email, please reply to this email so we can investigate.`

--- a/email/email.go
+++ b/email/email.go
@@ -111,11 +111,11 @@ func sendVerificationEmail(
 		return fmt.Errorf("error rendering email: %v", err)
 	}
 
-	log.Printf("email.htmlBody: %s\n", email.htmlBody)
-
 	if err := email.send(); err != nil {
 		return fmt.Errorf("error sending mail: %v", err)
 	}
+	log.Printf("sending verification email to %s for key %s",
+		emailAddress, publicKey.Fingerprint().Hex())
 	return nil
 }
 
@@ -247,6 +247,7 @@ func (e *email) send() error {
 	} else {
 		addr := fmt.Sprintf("%s:%s", smtpHost, smtpPort)
 		auth := smtp.PlainAuth("", smtpUsername, smtpPassword, smtpHost)
+		log.Printf("sending email to %s via %s", to.Address, addr)
 		return smtp.SendMail(addr, auth, from.Address, []string{to.Address}, buffer.Bytes())
 	}
 }

--- a/email/email.go
+++ b/email/email.go
@@ -134,6 +134,7 @@ func shouldSendVerificationEmail(txn *sql.Tx, email string) (bool, error) {
 		//    currently allow. The email_key_link must be deleted
 		//    before the email can be linked again. Note that this
 		//    happens if the whole linked *key* is deleted.
+		log.Printf("email '%s' already linked to a key, not sending email", email)
 		return false, nil
 	}
 

--- a/email/email_test.go
+++ b/email/email_test.go
@@ -82,16 +82,37 @@ func min(a, b int) int {
 }
 
 const expectedSubject string = `Verify test@example.com on Fluidkeys`
-const expectedHtml string = `Verify your email address to allow others to find your PGP key and send you encrypted secrets.
+const expectedHtml string = `<!DOCTYPE HTML>
 
-Click this link to verify your key now:
+<html>
+<body>
+<p>
+Verify your email address to allow others to find your PGP key and send you encrypted secrets.
+</p>
 
-<a href="https://example.com/test">Verify test@example.com and allow others to find your PGP key</a>
+<p>
+<a href="https://example.com/test">Verify test@example.com</a>
+</p>
 
----
+<p>
+If clicking the link above doesn't work, copy and paste this link into your browser:
+</p>
 
-You're receiving this email because a PGP public key was uploaded to Fluidkeys from 1.1.1.1 at 16:15:37 UTC on 15 June 2018.
+<p>
+<a href="https://example.com/test">https://example.com/test</a>
+</p>
 
+<hr>
+<p>
+You're receiving this email because a PGP public key was uploaded to <a href="https://www.fluidkeys.com">Fluidkeys</a> from 1.1.1.1 at 16:15:37 UTC on 15 June 2018.
+
+<p>
 Key A999B7498D1A8DC473E53C92309F635DAD1B5517 created 5 February 2016
+</p>
 
-If you aren't expecting this email, please reply to this email so we can investigate.`
+<p>
+If you aren't expecting this email, please reply to this email so we can investigate.
+</p>
+
+</body>
+</html>`

--- a/email/email_test.go
+++ b/email/email_test.go
@@ -1,0 +1,87 @@
+package email
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fluidkeys/fluidkeys/assert"
+	"github.com/fluidkeys/fluidkeys/fingerprint"
+)
+
+func TestRenderVerifyEmail(t *testing.T) {
+	now := time.Date(2018, 6, 15, 16, 15, 37, 0, time.UTC)
+	createdAt := time.Date(2016, 2, 5, 0, 0, 0, 0, time.UTC)
+	fp := fingerprint.MustParse("A999B7498D1A8DC473E53C92309F635DAD1B5517")
+
+	data := verifyEmail{
+		Email:            "test@example.com",
+		VerificationUrl:  "https://example.com/test",
+		RequestIpAddress: "1.1.1.1",
+		RequestTime:      now,
+		KeyFingerprint:   fp.Hex(),
+		KeyCreatedDate:   createdAt,
+	}
+
+	t.Run("test subject", func(t *testing.T) {
+		gotSubject, err := render(verifySubjectTemplate, data)
+		assert.ErrorIsNil(t, err)
+
+		expectedSubject := `Verify test@example.com on Fluidkeys`
+		assert.Equal(t, expectedSubject, gotSubject)
+	})
+
+	t.Run("test html body", func(t *testing.T) {
+		gotHtml, err := render(verifyHtmlBodyTemplate, data)
+		assert.ErrorIsNil(t, err)
+
+		assertEqualMultiLineStrings(t, expectedHtml, gotHtml)
+	})
+
+}
+
+func assertEqualMultiLineStrings(t *testing.T, expected string, got string) {
+	if expected == got {
+		return
+	}
+
+	expectedLines := strings.Split(expected, "\n")
+	gotLines := strings.Split(got, "\n")
+
+	var i int
+
+	for i < len(expectedLines) && i < len(gotLines) {
+		if expectedLines[i] != gotLines[i] {
+			fmt.Printf("< %s\n", expectedLines[i])
+			fmt.Printf("> %s\n", gotLines[i])
+		}
+
+		i += 1
+	}
+	// TODO: print out any extra lines present in 1 and not the other
+
+	t.Fatalf("strings differ: expected %d lines, got %d lines^^",
+		len(expectedLines), len(gotLines))
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+const expectedHtml string = `Verify your email address to allow others to find your PGP key and send you encrypted secrets.
+
+Click this link to verify your key now:
+
+<a href="https://example.com/test">Verify test@example.com and allow others to find your PGP key</a>
+
+---
+
+You're receiving this email because a PGP public key was uploaded to Fluidkeys from 1.1.1.1 at 16:15:37 UTC on 15 June 2018.
+
+Key A999B7498D1A8DC473E53C92309F635DAD1B5517 created 5 February 2016
+
+If you aren't expecting this email, please reply to this email so we can investigate.`

--- a/email/email_test.go
+++ b/email/email_test.go
@@ -28,7 +28,6 @@ func TestRenderVerifyEmail(t *testing.T) {
 		gotSubject, err := render(verifySubjectTemplate, data)
 		assert.ErrorIsNil(t, err)
 
-		expectedSubject := `Verify test@example.com on Fluidkeys`
 		assert.Equal(t, expectedSubject, gotSubject)
 	})
 
@@ -37,6 +36,16 @@ func TestRenderVerifyEmail(t *testing.T) {
 		assert.ErrorIsNil(t, err)
 
 		assertEqualMultiLineStrings(t, expectedHtml, gotHtml)
+	})
+
+	t.Run("test email.renderSubjectAndBody populates .subject and .htmlBody", func(t *testing.T) {
+		email := email{}
+
+		err := email.renderSubjectAndBody(data)
+		assert.ErrorIsNil(t, err)
+
+		assert.Equal(t, expectedSubject, email.subject)
+		assertEqualMultiLineStrings(t, expectedHtml, email.htmlBody)
 	})
 
 }
@@ -72,6 +81,7 @@ func min(a, b int) int {
 	return b
 }
 
+const expectedSubject string = `Verify test@example.com on Fluidkeys`
 const expectedHtml string = `Verify your email address to allow others to find your PGP key and send you encrypted secrets.
 
 Click this link to verify your key now:

--- a/vagrant/bashrc
+++ b/vagrant/bashrc
@@ -4,6 +4,7 @@ cd ~/go/src/github.com/fluidkeys/api
 
 export DATABASE_URL="postgres://vagrant:password@localhost:5432/vagrant"
 export TEST_DATABASE_URL="postgres://vagrant:password@localhost:5432/fkapi_test"
+export DISABLE_SEND_EMAIL="1"
 
 alias go="richgo"
 


### PR DESCRIPTION
* new database table email_verifications
* logic to decide if an upserted public key should get any verification emails
* code for rendering a verification email
* code for *sending* verification emails

for development you can set DISABLE_SEND_EMAIL=1 (included in vagrant bashrc)