### PR TITLE
case-insensitive search on email addresses

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fluidkeys/fluidkeys/pgpkey"
 	"github.com/gofrs/uuid"
 	"os"
+	"strings"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -135,8 +136,8 @@ func GetArmoredPublicKeyForEmail(txn *sql.Tx, email string) (
 		return "", false, err
 	}
 
-	if email != gotEmail {
-		panic(fmt.Errorf("queried for '%s', got back '%s'", email, gotEmail))
+	if strings.ToLower(email) != strings.ToLower(gotEmail) {
+		return "", false, fmt.Errorf("queried for '%s', got back '%s'", email, gotEmail)
 	}
 
 	return armoredPublicKey, true, nil

--- a/datastore/schema.go
+++ b/datastore/schema.go
@@ -66,4 +66,8 @@ var migrateDatabaseStatements = []string{
                 verify_user_agent TEXT,
                 verify_ip_address INET
     )`,
+
+	`CREATE EXTENSION IF NOT EXISTS citext`,
+
+	`ALTER TABLE email_key_link ALTER COLUMN email TYPE citext`,
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -101,6 +101,11 @@ func TestGetPublicKeyByEmailHandler(t *testing.T) {
 			response := callApi(t, "GET", "/v1/email/test4%2Bfoo%40example.com/key")
 			assertStatusCode(t, http.StatusOK, response.Code)
 		})
+
+		t.Run("with uppercase query for lowercase email", func(t *testing.T) {
+			response := callApi(t, "GET", "/v1/email/TEST4@example.com/key")
+			assertStatusCode(t, http.StatusOK, response.Code)
+		})
 	})
 
 	t.Run("ascii-armored endpoint", func(t *testing.T) {


### PR DESCRIPTION
rebase after #24

we use the postgres citext (case insensitive text) extension to *query* in
a case insensitive way, while *storing* with the original case.