### PR TITLE
datastore: CreateTeam -> UpsertTeam

### DIFF
--- a/datastore/team.go
+++ b/datastore/team.go
@@ -51,11 +51,19 @@ func TeamExists(txn *sql.Tx, teamUUID uuid.UUID) (bool, error) {
 	}
 }
 
-// CreateTeam creates a team in the database.
-// If a team already exists with team.UUID it returns an error
-func CreateTeam(txn *sql.Tx, team Team) error {
+// UpsertTeam creates a team in the database.
+// If a team already exists with team.UUID it updates the team.
+func UpsertTeam(txn *sql.Tx, team Team) error {
 	query := `INSERT INTO teams (uuid, created_at, roster, roster_signature)
-	          VALUES ($1, $2, $3, $4)`
+	          VALUES ($1, $2, $3, $4)
+              ON CONFLICT (uuid) DO UPDATE
+              SET roster           = EXCLUDED.roster,
+                  roster_signature = EXCLUDED.roster_signature`
+
+	// query := `INSERT INTO teams (uuid, created_at, roster, roster_signature)
+	//           VALUES ($1, $2)
+	// 	  ON CONFLICT (uid) DO UPDATE
+	// 	      SET armored_public_key=EXCLUDED.armored_public_key`
 
 	_, err := transactionOrDatabase(txn).Exec(
 		query,

--- a/server/listrequeststojointeamhandler_test.go
+++ b/server/listrequeststojointeamhandler_test.go
@@ -52,7 +52,7 @@ fingerprint = "BB3C 44BF 188D 56E6 35F4  A092 F73D 2F05 33D7 F9D6"
 		)
 
 		assert.NoError(t,
-			datastore.CreateTeam(nil, goodTeam),
+			datastore.UpsertTeam(nil, goodTeam),
 		)
 	}
 

--- a/server/teamshandler.go
+++ b/server/teamshandler.go
@@ -100,7 +100,7 @@ func createTeamHandler(w http.ResponseWriter, r *http.Request) {
 			CreatedAt:       time.Now(),
 		}
 
-		if err := datastore.CreateTeam(txn, team); err != nil {
+		if err := datastore.UpsertTeam(txn, team); err != nil {
 			return fmt.Errorf("error creating team: %v", err)
 		}
 

--- a/server/teamshandler_test.go
+++ b/server/teamshandler_test.go
@@ -353,7 +353,7 @@ func TestGetTeamHandler(t *testing.T) {
 	}
 
 	setup := func() {
-		assert.NoError(t, datastore.CreateTeam(nil, exampleTeam))
+		assert.NoError(t, datastore.UpsertTeam(nil, exampleTeam))
 	}
 
 	teardown := func() {
@@ -401,7 +401,7 @@ func TestGetTeamHandler(t *testing.T) {
 			CreatedAt: now,
 		}
 
-		assert.NoError(t, datastore.CreateTeam(nil, badRosterTeam))
+		assert.NoError(t, datastore.UpsertTeam(nil, badRosterTeam))
 		defer func() {
 			datastore.DeleteTeam(nil, badRosterTeam.UUID)
 		}()
@@ -430,7 +430,7 @@ func TestCreateRequestToJoinTeamHandler(t *testing.T) {
 	}
 
 	setup := func() {
-		assert.NoError(t, datastore.CreateTeam(nil, exampleTeam))
+		assert.NoError(t, datastore.UpsertTeam(nil, exampleTeam))
 
 		assert.NoError(t, datastore.UpsertPublicKey(nil, exampledata.ExamplePublicKey4))
 		assert.NoError(t,
@@ -507,7 +507,7 @@ func TestCreateRequestToJoinTeamHandler(t *testing.T) {
 			RosterSignature: "",
 			CreatedAt:       now,
 		}
-		assert.NoError(t, datastore.CreateTeam(nil, team))
+		assert.NoError(t, datastore.UpsertTeam(nil, team))
 		defer func() {
 			_, err := datastore.DeleteTeam(nil, team.UUID)
 			assert.NoError(t, err)
@@ -562,7 +562,7 @@ func TestCreateRequestToJoinTeamHandler(t *testing.T) {
 			RosterSignature: "",
 			CreatedAt:       now,
 		}
-		assert.NoError(t, datastore.CreateTeam(nil, team))
+		assert.NoError(t, datastore.UpsertTeam(nil, team))
 		defer func() {
 			_, err := datastore.DeleteTeam(nil, team.UUID)
 			assert.NoError(t, err)


### PR DESCRIPTION
allow the datastore to update a team's roster and roster signature.

note that the CreatedAt field is *not* updated :)