### PR TITLE
add placeholder "get team roster" endpoint

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -60,6 +60,11 @@ func init() {
 	).Methods("GET")
 
 	subrouter.HandleFunc(
+		"/team/{teamUUID}/roster",
+		getTeamRosterHandler,
+	).Methods("GET")
+
+	subrouter.HandleFunc(
 		"/team/{teamUUID}/requests-to-join/{requestUUID}",
 		deleteRequestToJoinTeamHandler,
 	).Methods("DELETE")

--- a/server/teamshandler.go
+++ b/server/teamshandler.go
@@ -275,6 +275,11 @@ func createRequestToJoinTeamHandler(w http.ResponseWriter, r *http.Request) {
 
 }
 
+func getTeamRosterHandler(w http.ResponseWriter, r *http.Request) {
+	writeJsonError(w, fmt.Errorf("not implemented"), http.StatusNotFound)
+	return
+}
+
 func deleteRequestToJoinTeamHandler(w http.ResponseWriter, r *http.Request) {
 }
 

--- a/v1structs/v1structs.go
+++ b/v1structs/v1structs.go
@@ -90,7 +90,10 @@ type GetTeamResponse struct {
 }
 
 // UpsertTeamRequest is the JSON structure containing a signed team roster.
-type UpsertTeamRequest struct {
+type UpsertTeamRequest = TeamRosterAndSignature
+
+// TeamRosterAndSignature contains a TOML team roster and an armored detached OpenPGP signature.
+type TeamRosterAndSignature struct {
 	// TeamRoster describes the members and configuration of a team.
 	// See github.com/fluidkeys/fluidkeys/teamroster
 	TeamRoster string `json:"teamRoster"`
@@ -120,6 +123,14 @@ type RequestToJoinTeam struct {
 	UUID        string `json:"uuid"`
 	Fingerprint string `json:"fingerprint"`
 	Email       string `json:"email"`
+}
+
+// GetTeamRosterResponse is the JSON structure containing the team's roster and detached signature,
+// encrypted to the key that requested it.
+type GetTeamRosterResponse struct {
+	// EncryptedMetadata is an ASCII-armored encrypted PGP message which decrypts to a
+	// `TeamRosterAndSignature` JSON structure.
+	EncryptedJSON string `json:"encryptedJSON"`
 }
 
 // ErrorResponse is the JSON structure returned when the API encounters an


### PR DESCRIPTION
* v1structs: add GetTeamRosterResponse

* factor out `TeamRosterAndSignature` so it can be used by both
  `GetTeamRosterResponse` and `UpsertTeamRequest`

note that `UpsertTeamRequest` is now defind with
`TeamRosterAndSignature` as an embedded type, meaning the latter's
fields are available directly through `UpsertTeamRequest`