### PR TITLE
LinkEmailToFingerprint: record email_verification

### DIFF
--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/fluidkeys/fluidkeys/assert"
 	"github.com/fluidkeys/fluidkeys/exampledata"
+	"github.com/gofrs/uuid"
 )
 
 func TestMain(m *testing.M) {
@@ -112,11 +113,11 @@ func TestEmailVerificationFunctions(t *testing.T) {
 		)
 		assert.NoError(t, err)
 
-		email, fingerprint, err := GetVerification(nil, *verificationUUID, now)
+		v, err := GetVerification(nil, *verificationUUID, now)
 		assert.NoError(t, err)
 
-		assert.Equal(t, "test@example.com", email)
-		assert.Equal(t, exampledata.ExampleFingerprint2, *fingerprint)
+		assert.Equal(t, "test@example.com", v.EmailSentTo)
+		assert.Equal(t, exampledata.ExampleFingerprint2, v.KeyFingerprint)
 	})
 
 	t.Run("test MarkVerificationAsVerified", func(t *testing.T) {
@@ -154,70 +155,108 @@ func TestLinkEmailToFingerprint(t *testing.T) {
 	email := "test@example.com"
 	fingerprint := exampledata.ExampleFingerprint2
 
-	t.Run("test create", func(t *testing.T) {
+	verificationUUID, err := CreateVerification(
+		nil,
+		email,
+		fingerprint,
+		"fake user agent",
+		"0.0.0.0",
+		now,
+	)
 
-		verificationUUID, err := CreateVerification(
-			nil,
-			email,
-			fingerprint,
-			"fake user agent",
-			"0.0.0.0",
-			now,
-		)
+	assert.NoError(t, err)
 
+	err = MarkVerificationAsVerified(nil, *verificationUUID, "fake user agent 2", "1.1.1.1")
+	assert.NoError(t, err)
+
+	err = LinkEmailToFingerprint(nil, email, fingerprint, verificationUUID)
+	assert.NoError(t, err)
+
+	t.Run("read back linked key ID and verification UUID for email address", func(t *testing.T) {
+		var keyID int
+		query := `SELECT id FROM keys WHERE fingerprint=$1`
+		err = db.QueryRow(query, dbFormat(fingerprint)).Scan(&keyID)
 		assert.NoError(t, err)
 
-		err = MarkVerificationAsVerified(nil, *verificationUUID, "fake user agent 2", "1.1.1.1")
+		query = `SELECT key_id, email_verification_uuid
+				FROM email_key_link
+				WHERE email=$1`
+
+		var readBackKeyID int
+		var readBackVerificationUUID *uuid.UUID
+
+		err = db.QueryRow(query, email).Scan(&readBackKeyID, &readBackVerificationUUID)
 		assert.NoError(t, err)
 
-		err = LinkEmailToFingerprint(nil, email, fingerprint)
+		assert.Equal(t, keyID, readBackKeyID)
+		assert.Equal(t, verificationUUID, readBackVerificationUUID)
+	})
+
+	t.Run("with nil email_verification_uuid", func(t *testing.T) {
+		var keyID int
+		query := `SELECT id FROM keys WHERE fingerprint=$1`
+		err = db.QueryRow(query, dbFormat(fingerprint)).Scan(&keyID)
 		assert.NoError(t, err)
 
-		t.Run("read back linked key ID for email address", func(t *testing.T) {
-			var keyID int
-			query := `SELECT id FROM keys WHERE fingerprint=$1`
-			err = db.QueryRow(query, dbFormat(fingerprint)).Scan(&keyID)
-			assert.NoError(t, err)
+		err = LinkEmailToFingerprint(nil, email, fingerprint, nil)
+		assert.NoError(t, err)
 
-			query = `SELECT key_id
+		t.Run("read back updated database row", func(t *testing.T) {
+			query = `SELECT key_id, email_verification_uuid
 				FROM email_key_link
 				WHERE email=$1`
 
 			var readBackKeyID int
+			var readBackVerificationUUID *uuid.UUID
 
-			err = db.QueryRow(query, email).Scan(&readBackKeyID)
+			err = db.QueryRow(query, email).Scan(&readBackKeyID, &readBackVerificationUUID)
 			assert.NoError(t, err)
 
 			assert.Equal(t, keyID, readBackKeyID)
+			if readBackVerificationUUID != nil {
+				t.Fatalf("expected to read back email_verification_uuid of nl, got %v",
+					readBackVerificationUUID)
+			}
 		})
 
 	})
 
-	t.Run("test update can set key to a new key", func(t *testing.T) {
+	t.Run("update existing row", func(t *testing.T) {
 		updatedFingerprint := exampledata.ExampleFingerprint3
 
 		err := UpsertPublicKey(nil, exampledata.ExamplePublicKey3)
 		assert.NoError(t, err)
 
-		err = LinkEmailToFingerprint(nil, email, updatedFingerprint)
+		updatedVerificationUUID, err := CreateVerification(
+			nil,
+			email,
+			updatedFingerprint,
+			"fake user agent",
+			"0.0.0.0",
+			now,
+		)
+
+		err = LinkEmailToFingerprint(nil, email, updatedFingerprint, updatedVerificationUUID)
 		assert.NoError(t, err)
 
-		t.Run("read back updated key ID for email address", func(t *testing.T) {
+		t.Run("read back updated database row", func(t *testing.T) {
 			var keyID int
 			query := `SELECT id FROM keys WHERE fingerprint=$1`
 			err = db.QueryRow(query, dbFormat(updatedFingerprint)).Scan(&keyID)
 			assert.NoError(t, err)
 
-			query = `SELECT key_id
+			query = `SELECT key_id, email_verification_uuid
 				FROM email_key_link
 				WHERE email=$1`
 
 			var readBackKeyID int
+			var readBackUUID *uuid.UUID
 
-			err = db.QueryRow(query, email).Scan(&readBackKeyID)
+			err = db.QueryRow(query, email).Scan(&readBackKeyID, &readBackUUID)
 			assert.NoError(t, err)
 
 			assert.Equal(t, keyID, readBackKeyID)
+			assert.Equal(t, *updatedVerificationUUID, *readBackUUID)
 		})
 
 	})

--- a/datastore/schema.go
+++ b/datastore/schema.go
@@ -104,14 +104,19 @@ var migrateDatabaseStatements = []string{
 				ALTER TABLE email_verifications DROP COLUMN IF EXISTS id;
 		END IF;
 	END $$`,
+
+	`ALTER TABLE email_key_link
+	     ADD COLUMN IF NOT EXISTS email_verification_uuid UUID
+		     REFERENCES email_verifications(uuid)
+		     ON DELETE SET NULL`,
 }
 
 // allTables is used by the test helper DropAllTheTables to keep track of what tables to
 // tear down after running tests
 var allTables = []string{
 	"single_use_uuids",
-	"email_verifications",
 	"email_key_link",
+	"email_verifications",
 	"secrets",
 	"keys",
 	"team_join_requests",

--- a/datastore/schema.go
+++ b/datastore/schema.go
@@ -109,6 +109,21 @@ var migrateDatabaseStatements = []string{
 	     ADD COLUMN IF NOT EXISTS email_verification_uuid UUID
 		     REFERENCES email_verifications(uuid)
 		     ON DELETE SET NULL`,
+
+	`UPDATE
+	  email_key_link
+	SET
+	  email_verification_uuid=B.email_verification_uuid
+	FROM
+	  (
+	    SELECT email_key_link.id AS email_key_link_id,
+	           email_verifications.uuid AS email_verification_uuid
+	    FROM email_key_link
+	    JOIN email_verifications ON email_key_link.key_id = email_verifications.key_id
+	    WHERE email_key_link.email = email_verifications.email_sent_to
+	    AND email_verifications.verify_ip_address IS NOT NULL
+	  ) B
+	WHERE email_key_link.id = B.email_key_link_id`,
 }
 
 // allTables is used by the test helper DropAllTheTables to keep track of what tables to

--- a/datastore/schema.go
+++ b/datastore/schema.go
@@ -123,7 +123,8 @@ var migrateDatabaseStatements = []string{
 	    WHERE email_key_link.email = email_verifications.email_sent_to
 	    AND email_verifications.verify_ip_address IS NOT NULL
 	  ) B
-	WHERE email_key_link.id = B.email_key_link_id`,
+	WHERE email_key_link.id = B.email_key_link_id AND
+          email_key_link.email_verification_uuid IS NULL`,
 }
 
 // allTables is used by the test helper DropAllTheTables to keep track of what tables to

--- a/server/listrequeststojointeamhandler_test.go
+++ b/server/listrequeststojointeamhandler_test.go
@@ -47,7 +47,7 @@ fingerprint = "BB3C 44BF 188D 56E6 35F4  A092 F73D 2F05 33D7 F9D6"
 
 		assert.NoError(t,
 			datastore.LinkEmailToFingerprint(
-				nil, "test4@example.com", exampledata.ExampleFingerprint4,
+				nil, "test4@example.com", exampledata.ExampleFingerprint4, nil,
 			),
 		)
 
@@ -119,7 +119,7 @@ fingerprint = "BB3C 44BF 188D 56E6 35F4  A092 F73D 2F05 33D7 F9D6"
 
 		assert.NoError(t, datastore.UpsertPublicKey(nil, exampledata.ExamplePublicKey2))
 		assert.NoError(t,
-			datastore.LinkEmailToFingerprint(nil, "test2@example.com", mismatchedFingerprint))
+			datastore.LinkEmailToFingerprint(nil, "test2@example.com", mismatchedFingerprint, nil))
 
 		assert.NoError(t, err)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,6 +5,15 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/fluidkeys/api/datastore"
 	"github.com/fluidkeys/api/v1structs"
 	"github.com/fluidkeys/crypto/openpgp"
@@ -15,14 +24,6 @@ import (
 	"github.com/fluidkeys/fluidkeys/fingerprint"
 	"github.com/fluidkeys/fluidkeys/pgpkey"
 	"github.com/gofrs/uuid"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"strings"
-	"testing"
-	"time"
 )
 
 func TestMain(m *testing.M) {
@@ -68,10 +69,14 @@ func TestGetPublicKeyByEmailHandler(t *testing.T) {
 		datastore.UpsertPublicKey(nil, exampledata.ExamplePublicKey4),
 	)
 	assert.NoError(t,
-		datastore.LinkEmailToFingerprint(nil, "test4@example.com", exampledata.ExampleFingerprint4),
+		datastore.LinkEmailToFingerprint(
+			nil, "test4@example.com", exampledata.ExampleFingerprint4, nil,
+		),
 	)
 	assert.NoError(t,
-		datastore.LinkEmailToFingerprint(nil, "test4+foo@example.com", exampledata.ExampleFingerprint4),
+		datastore.LinkEmailToFingerprint(
+			nil, "test4+foo@example.com", exampledata.ExampleFingerprint4, nil,
+		),
 	)
 
 	t.Run("JSON endpoint", func(t *testing.T) {

--- a/server/teamshandler_test.go
+++ b/server/teamshandler_test.go
@@ -68,7 +68,7 @@ is_admin = false
 
 		assert.NoError(t,
 			datastore.LinkEmailToFingerprint(
-				nil, "test4@example.com", exampledata.ExampleFingerprint4,
+				nil, "test4@example.com", exampledata.ExampleFingerprint4, nil,
 			),
 		)
 
@@ -158,7 +158,7 @@ is_admin = false
 
 		assert.NoError(t, datastore.UpsertPublicKey(nil, exampledata.ExamplePublicKey2))
 		assert.NoError(t,
-			datastore.LinkEmailToFingerprint(nil, "test2@example.com", mismatchedFingerprint))
+			datastore.LinkEmailToFingerprint(nil, "test2@example.com", mismatchedFingerprint, nil))
 
 		assert.NoError(t, err)
 
@@ -468,7 +468,7 @@ is_admin = true
 
 			assert.NoError(t,
 				datastore.LinkEmailToFingerprint(
-					nil, "test3@example.com", exampledata.ExampleFingerprint3,
+					nil, "test3@example.com", exampledata.ExampleFingerprint3, nil,
 				),
 			)
 
@@ -605,7 +605,7 @@ func TestCreateRequestToJoinTeamHandler(t *testing.T) {
 		assert.NoError(t, datastore.UpsertPublicKey(nil, exampledata.ExamplePublicKey4))
 		assert.NoError(t,
 			datastore.LinkEmailToFingerprint(
-				nil, "test4@example.com", exampledata.ExampleFingerprint4,
+				nil, "test4@example.com", exampledata.ExampleFingerprint4, nil,
 			))
 	}
 
@@ -689,7 +689,7 @@ func TestCreateRequestToJoinTeamHandler(t *testing.T) {
 
 		assert.NoError(t,
 			datastore.LinkEmailToFingerprint(
-				nil, "conflicting-example@example.com", exampledata.ExampleFingerprint4,
+				nil, "conflicting-example@example.com", exampledata.ExampleFingerprint4, nil,
 			))
 
 		firstResponse := callAPI(t,
@@ -703,7 +703,7 @@ func TestCreateRequestToJoinTeamHandler(t *testing.T) {
 		assert.NoError(t, datastore.UpsertPublicKey(nil, exampledata.ExamplePublicKey2))
 		assert.NoError(t,
 			datastore.LinkEmailToFingerprint(
-				nil, "conflicting-example@example.com", exampledata.ExampleFingerprint2,
+				nil, "conflicting-example@example.com", exampledata.ExampleFingerprint2, nil,
 			))
 
 		secondResponse := callAPI(t,
@@ -798,7 +798,7 @@ fingerprint = "BB3C 44BF 188D 56E6 35F4  A092 F73D 2F05 33D7 F9D6"
 
 		assert.NoError(t,
 			datastore.LinkEmailToFingerprint(
-				nil, "test4@example.com", exampledata.ExampleFingerprint4,
+				nil, "test4@example.com", exampledata.ExampleFingerprint4, nil,
 			),
 		)
 


### PR DESCRIPTION
When we create a new row in `email_key_link` (via LinkEmailToFingerprint),
record the UUID of the associated `email_verification` row.

* LinkEmailToFingerprint: also take a verificationUUID
* GetVerification: return a `EmailVerification` struct (which contains
 the UUID) rather than `email`, `fingerprint`
* db schema: link email_key_link back to email_verification_uuid
* db migration: populate `email_verification_uuid` for all existing rows in 
  `email_key_link`