### PR TITLE
add printexpiredkeys command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 run:
 	firejail --seccomp.drop=sendfile realize start
 
-.PHONY: run_collectors
-run_collectors:
-	go run main.go collect
+.PHONY: print_expired_keys
+print_expired_keys:
+	go run cmd/printexpiredkeys/printexpiredkeys.go
 
 .PHONY: migrate
 migrate:

--- a/cmd/printexpiredkeys/printexpiredkeys.go
+++ b/cmd/printexpiredkeys/printexpiredkeys.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/fluidkeys/api/datastore"
+)
+
+func main() {
+	err := datastore.Initialize(datastore.MustReadDatabaseURL())
+	if err != nil {
+		panic(err)
+	}
+
+	expiredKeys, err := datastore.ListExpiredKeys()
+	if err != nil {
+		fmt.Printf("error sending emails: %v\n", err)
+		os.Exit(1)
+	}
+
+	for i := range expiredKeys {
+		email, err := expiredKeys[i].Email()
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("%s\n", email)
+	}
+}

--- a/datastore/emailqueries.go
+++ b/datastore/emailqueries.go
@@ -1,0 +1,83 @@
+package datastore
+
+import (
+	"log"
+	"strings"
+	"time"
+
+	"github.com/fluidkeys/fluidkeys/pgpkey"
+)
+
+// ListExpiredKeys returns all pgp keys that have expired.
+func ListExpiredKeys() (keys []*pgpkey.PgpKey, err error) {
+	query := `SELECT keys.armored_public_key,
+                     email_key_link.email
+              FROM email_key_link
+              INNER JOIN keys                ON email_key_link.key_id = keys.id`
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var armoredPublic string
+		var verifiedEmail string
+		err = rows.Scan(&armoredPublic, &verifiedEmail)
+		if err != nil {
+			return nil, err
+		}
+
+		key, err := pgpkey.LoadFromArmoredPublicKey(armoredPublic)
+		if err != nil {
+			log.Printf("error loading key: %v", err)
+			continue
+		}
+
+		if !doesPrimaryEmailMatch(key, verifiedEmail) {
+			continue
+		}
+
+		if anyUIDHasExpired(key, time.Now()) {
+			keys = append(keys, key)
+		}
+	}
+	return keys, nil
+}
+
+func doesPrimaryEmailMatch(key *pgpkey.PgpKey, email string) bool {
+	keyEmail, err := key.Email()
+	if err != nil {
+		log.Printf("error getting email for key: %v", err)
+		return false
+	}
+
+	return emailMatches(keyEmail, email)
+}
+
+func emailMatches(firstEmail string, secondEmail string) bool {
+	// TODO: make this less naive
+	return strings.ToLower(firstEmail) == strings.ToLower(secondEmail)
+}
+
+// anyUIDHasExpired returns true if all these things are true:
+// * it has an encryption subkey (TODO)
+// * its primary user ID has not expired
+//   - note: we just check if *any* user id has expired, and call that invalid.
+func anyUIDHasExpired(key *pgpkey.PgpKey, now time.Time) bool {
+	for _, id := range key.Identities {
+		hasExpiry, expiryTime := pgpkey.CalculateExpiry(
+			key.PrimaryKey.CreationTime, // not to be confused with the time of the *signature*
+			id.SelfSignature.KeyLifetimeSecs,
+		)
+		if !hasExpiry {
+			continue
+		}
+
+		if hasExpired := expiryTime.Before(now); hasExpired == true {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
this is what I used to make the one-off manual email I sent this
afternoon.

this outputs the primary email address for any keys that have expired.

note:

* the primary user ID (email) on the key must be verified
* we consider it expired if *any* uid has expired