### PR TITLE
Email keys expiring in 3 days

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ run:
 print_expired_keys:
 	go run cmd/printexpiredkeys/printexpiredkeys.go
 
+.PHONY: send_emails
+send_emails:
+	go run cmd/sendemails/sendemails.go
+
 .PHONY: migrate
 migrate:
 	go run cmd/migrate/migrate.go

--- a/cmd/sendemails/sendemails.go
+++ b/cmd/sendemails/sendemails.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/fluidkeys/api/datastore"
+	"github.com/fluidkeys/api/email"
+)
+
+func main() {
+	err := datastore.Initialize(datastore.MustReadDatabaseURL())
+	if err != nil {
+		panic(err)
+	}
+
+	if err := email.SendFromCron(); err != nil {
+		fmt.Printf("error sending emails: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/email/helpkeyexpires.go
+++ b/email/helpkeyexpires.go
@@ -1,0 +1,121 @@
+package email
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/fluidkeys/api/datastore"
+	fpr "github.com/fluidkeys/fluidkeys/fingerprint"
+)
+
+// SendKeyExpiresEmails sends expiry reminders for keys expiring in 14, 7, 3 days
+func SendKeyExpiresEmails() error {
+	const from = "Fluidkeys <help@mail.fluidkeys.com>"
+	const replyTo = "Fluidkeys <help@fluidkeys.com>"
+
+	keysExpiring, err := datastore.ListKeysExpiring()
+	if err != nil {
+		return fmt.Errorf("error calling datastore.ListKeysKeysExpiring: %v", err)
+	}
+
+	var numSent, numErrors, numAlreadySent int
+
+	for i := range keysExpiring {
+		daysUntilExpiry := keysExpiring[i].DaysUntilExpiry
+		userProfile := keysExpiring[i].UserProfile
+		key := userProfile.Key
+		primaryEmail := keysExpiring[i].PrimaryEmail
+
+		switch daysUntilExpiry {
+		case 3, 5:
+
+			templateData := helpKeyExpires3Days{
+				Email:       primaryEmail,
+				Fingerprint: key.Fingerprint(),
+			}
+
+			// rate-limit this type of email to once every 7 days. this allows us to run this
+			// query multiple times on the same day without sending duplicate emails.
+			rateLimit := time.Duration(7*24) * time.Hour
+			err := sendEmail(
+				userProfile.UUID,
+				templateData,
+				primaryEmail,
+				from,
+				replyTo,
+				&rateLimit)
+
+			if err == errRateLimit {
+				numAlreadySent++
+				continue
+			} else if err != nil {
+				fmt.Printf("error sending email: %v\n", err)
+				numErrors++
+				continue
+			}
+
+			numSent++
+
+			fmt.Printf(
+				"sent 3-day reminder for %s to %s\n", key.Fingerprint().Hex(), primaryEmail,
+			)
+
+		default:
+			continue
+		}
+	}
+
+	fmt.Printf("key expiring emails: %d sent, %d failed, %d already sent (rate-limited).\n",
+		numSent, numErrors, numAlreadySent)
+
+	return nil
+}
+
+// helpKeyExpires3Days holds the data required to populate the
+// "help_key_expires_3_days" email template
+type helpKeyExpires3Days struct {
+	Email       string
+	Fingerprint fpr.Fingerprint
+}
+
+func (e helpKeyExpires3Days) ID() string { return "help_key_expires_3_days" }
+func (e helpKeyExpires3Days) RenderInto(eml *email) (err error) {
+	eml.subject = helpKeyExpires3DaysSubject
+	eml.htmlBody, err = render(helpKeyExpires3DaysBodyTemplate, e)
+	return err
+}
+
+const helpKeyExpires3DaysSubject = "❌ PGP key expiring: we'll delete it in 3 days"
+const helpKeyExpires3DaysBodyTemplate string = `You installed Fluidkeys[0] and uploaded a public key to our server. Great!
+
+Normally, Fluidkeys extends and uploads your public key automatically to save you the hassle.
+
+It looks like something stopped working on your machine as we don't see an updated key on our server.
+
+In 3 days your key will expire and we'll delete it from our server.
+
+Email: {{.Email}}
+Fingerprint: {{.Fingerprint}}
+
+
+## Extend and upload your key
+
+You can extend and upload your key now by running:
+
+fk key maintain
+fk key upload
+
+It should ask you to switch on automatic maintenance so that this doesn't happen again.
+
+Any problems, hit reply and we'll help you out.
+
+
+## We'll delete your data automatically
+
+If you don't extend your key, we'll automatically delete your public key from our server. This includes your email address so you won't receive any more automated emails like this one.
+
+
+[0] https://www.fluidkeys.com
+
+Don't want to receive expiry reminders? Hit reply and let us know.  
+`

--- a/email/helpkeyexpires.go
+++ b/email/helpkeyexpires.go
@@ -27,7 +27,7 @@ func SendKeyExpiresEmails() error {
 		primaryEmail := keysExpiring[i].PrimaryEmail
 
 		switch daysUntilExpiry {
-		case 3, 5:
+		case 3:
 
 			templateData := helpKeyExpires3Days{
 				Email:       primaryEmail,

--- a/email/sendfromcron.go
+++ b/email/sendfromcron.go
@@ -1,0 +1,8 @@
+package email
+import "fmt"
+
+// SendFromCron is periodically called from cron, figures out which it needs to
+// send, sends them, and records they've been sent in the datastore.
+func SendFromCron() error {
+	return fmt.Errorf("not implemented")
+}

--- a/email/sendfromcron.go
+++ b/email/sendfromcron.go
@@ -1,8 +1,14 @@
 package email
-import "fmt"
+
+import "log"
 
 // SendFromCron is periodically called from cron, figures out which it needs to
 // send, sends them, and records they've been sent in the datastore.
-func SendFromCron() error {
-	return fmt.Errorf("not implemented")
+func SendFromCron() (sawError error) {
+	if err := SendKeyExpiresEmails(); err != nil {
+		log.Printf("error calling SendKeyExpiresEmails: %v", err)
+		sawError = err
+	}
+
+	return sawError
 }


### PR DESCRIPTION
* add SendKeyExpiresEmails, call from sendemails
  this sends 3-day expiry reminders.
  call it from `email/sendfromcron` (which is in turn called from
  `cmd/sendemails/sendemails.go`)

* add sendEmail helper function
  this is a generic helper function which takes an email template (a struct
  implemeting the emailTemplateInterface) and:
  
  * checks the rate-limit to see if it's OK to send this type of email again
  * lets the template render the email (using new
    emailTemplateInterface.RenderInto)
  * sends the email
  * records that it was sent