### PR TITLE
rename render -> renderHTML, add renderText

### DIFF
--- a/email/email.go
+++ b/email/email.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"html/template"
 	"log"
 	"net/mail"
 	"net/smtp"
@@ -246,12 +245,12 @@ func (e *email) renderSubjectAndBody(data interface{}) (err error) {
 
 	switch templateName {
 	case "verify":
-		e.subject, err = render(verifySubjectTemplate, data)
+		e.subject, err = renderText(verifySubjectTemplate, data)
 		if err != nil {
 			return err
 		}
 
-		e.htmlBody, err = render(verifyHtmlBodyTemplate, data)
+		e.htmlBody, err = renderHTML(verifyHtmlBodyTemplate, data)
 		if err != nil {
 			return err
 		}
@@ -312,21 +311,6 @@ func (e *email) send() error {
 	}
 }
 
-func render(templateText string, emailTemplateData interface{}) (string, error) {
-
-	t, err := template.New("").Funcs(funcMap).Parse(templateText)
-
-	if err != nil {
-		return "", err
-	}
-	buf := bytes.NewBuffer(nil)
-	err = t.Execute(buf, emailTemplateData)
-	if err != nil {
-		return "", err
-	}
-	return buf.String(), nil
-}
-
 var (
 	disableSendEmail bool
 	smtpHost         string
@@ -343,16 +327,6 @@ type verifyEmail struct {
 	RequestTime      time.Time
 	KeyFingerprint   string
 	KeyCreatedDate   time.Time
-}
-
-// funcMap defines template functions that transform variables into strings in the template
-var funcMap = template.FuncMap{
-	"FormatDateTime": func(t time.Time) string {
-		return t.Format("15:04:05 MST on 2 January 2006")
-	},
-	"FormatDate": func(t time.Time) string {
-		return t.Format("2 January 2006")
-	},
 }
 
 var errRateLimit = fmt.Errorf("rate limit: not sending same email so soon")

--- a/email/email_test.go
+++ b/email/email_test.go
@@ -25,14 +25,14 @@ func TestRenderVerifyEmail(t *testing.T) {
 	}
 
 	t.Run("test subject", func(t *testing.T) {
-		gotSubject, err := render(verifySubjectTemplate, data)
+		gotSubject, err := renderText(verifySubjectTemplate, data)
 		assert.NoError(t, err)
 
 		assert.Equal(t, expectedSubject, gotSubject)
 	})
 
 	t.Run("test html body", func(t *testing.T) {
-		gotHtml, err := render(verifyHtmlBodyTemplate, data)
+		gotHtml, err := renderHTML(verifyHtmlBodyTemplate, data)
 		assert.NoError(t, err)
 
 		assertEqualMultiLineStrings(t, expectedHtml, gotHtml)

--- a/email/helpkeydeleted.go
+++ b/email/helpkeydeleted.go
@@ -54,7 +54,7 @@ type helpKeyExpiredDeleted struct {
 func (e helpKeyExpiredDeleted) ID() string { return "help_key_expired_deleted" }
 func (e helpKeyExpiredDeleted) RenderInto(eml *email) (err error) {
 	eml.subject = helpKeyExpiredDeletedSubject
-	eml.htmlBody, err = render(helpKeyExpiredDeletedBodyTemplate, e)
+	eml.htmlBody, err = renderHTML(helpKeyExpiredDeletedBodyTemplate, e)
 	return err
 }
 

--- a/email/helpkeyexpires.go
+++ b/email/helpkeyexpires.go
@@ -89,7 +89,7 @@ type helpKeyExpires3Days struct {
 func (e helpKeyExpires3Days) ID() string { return "help_key_expires_3_days" }
 func (e helpKeyExpires3Days) RenderInto(eml *email) (err error) {
 	eml.subject = helpKeyExpires3DaysSubject
-	eml.htmlBody, err = render(helpKeyExpires3DaysBodyTemplate, e)
+	eml.htmlBody, err = renderHTML(helpKeyExpires3DaysBodyTemplate, e)
 	return err
 }
 
@@ -137,7 +137,7 @@ type helpKeyExpires7Days struct {
 func (e helpKeyExpires7Days) ID() string { return "help_key_expires_7_days" }
 func (e helpKeyExpires7Days) RenderInto(eml *email) (err error) {
 	eml.subject = helpKeyExpires7DaysSubject
-	eml.htmlBody, err = render(helpKeyExpires7DaysBodyTemplate, e)
+	eml.htmlBody, err = renderHTML(helpKeyExpires7DaysBodyTemplate, e)
 	return err
 }
 
@@ -185,7 +185,7 @@ type helpKeyExpires14Days struct {
 func (e helpKeyExpires14Days) ID() string { return "help_key_expires_14_days" }
 func (e helpKeyExpires14Days) RenderInto(eml *email) (err error) {
 	eml.subject = helpKeyExpires14DaysSubject
-	eml.htmlBody, err = render(helpKeyExpires14DaysBodyTemplate, e)
+	eml.htmlBody, err = renderHTML(helpKeyExpires14DaysBodyTemplate, e)
 	return err
 }
 

--- a/email/render.go
+++ b/email/render.go
@@ -1,0 +1,48 @@
+package email
+
+import (
+	"bytes"
+	htmltemplate "html/template"
+	texttemplate "text/template"
+	"time"
+)
+
+func renderText(templateText string, emailTemplateData interface{}) (string, error) {
+
+	t, err := texttemplate.New("").Parse(templateText)
+
+	if err != nil {
+		return "", err
+	}
+	buf := bytes.NewBuffer(nil)
+	err = t.Execute(buf, emailTemplateData)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func renderHTML(templateText string, emailTemplateData interface{}) (string, error) {
+
+	t, err := htmltemplate.New("").Funcs(funcMap).Parse(templateText)
+
+	if err != nil {
+		return "", err
+	}
+	buf := bytes.NewBuffer(nil)
+	err = t.Execute(buf, emailTemplateData)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// funcMap defines template functions that transform variables into strings in the template
+var funcMap = htmltemplate.FuncMap{
+	"FormatDateTime": func(t time.Time) string {
+		return t.Format("15:04:05 MST on 2 January 2006")
+	},
+	"FormatDate": func(t time.Time) string {
+		return t.Format("2 January 2006")
+	},
+}


### PR DESCRIPTION
so that we're prepared to render plaintext emails as text, not HTML

Also, use renderText for the verification email subject, fixing this
bug:

https://trello.com/c/R2uR1hEk