### PR TITLE
render & send text emails as text, not HTML

### DIFF
--- a/cmd/sendtestemails.go
+++ b/cmd/sendtestemails.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/fluidkeys/api/email"
+)
+
+// SendTestEmails sends test emails to the given email address.
+func SendTestEmails() (exitCode int) {
+	if len(os.Args) != 3 {
+		fmt.Printf("Usage: send_test_emails <to_email>\n")
+		return 1
+	}
+
+	to := os.Args[2]
+	fmt.Printf("Sending test emails to %s\n", to)
+
+	if err := email.SendTestEmails(to); err != nil {
+		fmt.Printf("error sending test emails: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/email/email.go
+++ b/email/email.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"html/template"
 	"log"
 	"net/mail"
 	"net/smtp"
@@ -246,12 +245,12 @@ func (e *email) renderSubjectAndBody(data interface{}) (err error) {
 
 	switch templateName {
 	case "verify":
-		e.subject, err = render(verifySubjectTemplate, data)
+		e.subject, err = renderText(verifySubjectTemplate, data)
 		if err != nil {
 			return err
 		}
 
-		e.htmlBody, err = render(verifyHtmlBodyTemplate, data)
+		e.htmlBody, err = renderHTML(verifyHtmlBodyTemplate, data)
 		if err != nil {
 			return err
 		}
@@ -312,21 +311,6 @@ func (e *email) send() error {
 	}
 }
 
-func render(templateText string, emailTemplateData interface{}) (string, error) {
-
-	t, err := template.New("").Funcs(funcMap).Parse(templateText)
-
-	if err != nil {
-		return "", err
-	}
-	buf := bytes.NewBuffer(nil)
-	err = t.Execute(buf, emailTemplateData)
-	if err != nil {
-		return "", err
-	}
-	return buf.String(), nil
-}
-
 var (
 	disableSendEmail bool
 	smtpHost         string
@@ -343,16 +327,6 @@ type verifyEmail struct {
 	RequestTime      time.Time
 	KeyFingerprint   string
 	KeyCreatedDate   time.Time
-}
-
-// funcMap defines template functions that transform variables into strings in the template
-var funcMap = template.FuncMap{
-	"FormatDateTime": func(t time.Time) string {
-		return t.Format("15:04:05 MST on 2 January 2006")
-	},
-	"FormatDate": func(t time.Time) string {
-		return t.Format("2 January 2006")
-	},
 }
 
 var errRateLimit = fmt.Errorf("rate limit: not sending same email so soon")

--- a/email/email_test.go
+++ b/email/email_test.go
@@ -25,14 +25,14 @@ func TestRenderVerifyEmail(t *testing.T) {
 	}
 
 	t.Run("test subject", func(t *testing.T) {
-		gotSubject, err := render(verifySubjectTemplate, data)
+		gotSubject, err := renderText(verifySubjectTemplate, data)
 		assert.NoError(t, err)
 
 		assert.Equal(t, expectedSubject, gotSubject)
 	})
 
 	t.Run("test html body", func(t *testing.T) {
-		gotHtml, err := render(verifyHtmlBodyTemplate, data)
+		gotHtml, err := renderHTML(verifyHtmlBodyTemplate, data)
 		assert.NoError(t, err)
 
 		assertEqualMultiLineStrings(t, expectedHtml, gotHtml)

--- a/email/helpkeydeleted.go
+++ b/email/helpkeydeleted.go
@@ -54,7 +54,7 @@ type helpKeyExpiredDeleted struct {
 func (e helpKeyExpiredDeleted) ID() string { return "help_key_expired_deleted" }
 func (e helpKeyExpiredDeleted) RenderInto(eml *email) (err error) {
 	eml.subject = helpKeyExpiredDeletedSubject
-	eml.htmlBody, err = render(helpKeyExpiredDeletedBodyTemplate, e)
+	eml.htmlBody, err = renderHTML(helpKeyExpiredDeletedBodyTemplate, e)
 	return err
 }
 

--- a/email/helpkeydeleted.go
+++ b/email/helpkeydeleted.go
@@ -54,7 +54,7 @@ type helpKeyExpiredDeleted struct {
 func (e helpKeyExpiredDeleted) ID() string { return "help_key_expired_deleted" }
 func (e helpKeyExpiredDeleted) RenderInto(eml *email) (err error) {
 	eml.subject = helpKeyExpiredDeletedSubject
-	eml.htmlBody, err = renderHTML(helpKeyExpiredDeletedBodyTemplate, e)
+	eml.textBody, err = renderText(helpKeyExpiredDeletedBodyTemplate, e)
 	return err
 }
 

--- a/email/helpkeyexpires.go
+++ b/email/helpkeyexpires.go
@@ -89,7 +89,7 @@ type helpKeyExpires3Days struct {
 func (e helpKeyExpires3Days) ID() string { return "help_key_expires_3_days" }
 func (e helpKeyExpires3Days) RenderInto(eml *email) (err error) {
 	eml.subject = helpKeyExpires3DaysSubject
-	eml.htmlBody, err = renderHTML(helpKeyExpires3DaysBodyTemplate, e)
+	eml.textBody, err = renderText(helpKeyExpires3DaysBodyTemplate, e)
 	return err
 }
 
@@ -137,7 +137,7 @@ type helpKeyExpires7Days struct {
 func (e helpKeyExpires7Days) ID() string { return "help_key_expires_7_days" }
 func (e helpKeyExpires7Days) RenderInto(eml *email) (err error) {
 	eml.subject = helpKeyExpires7DaysSubject
-	eml.htmlBody, err = renderHTML(helpKeyExpires7DaysBodyTemplate, e)
+	eml.textBody, err = renderText(helpKeyExpires7DaysBodyTemplate, e)
 	return err
 }
 
@@ -185,7 +185,7 @@ type helpKeyExpires14Days struct {
 func (e helpKeyExpires14Days) ID() string { return "help_key_expires_14_days" }
 func (e helpKeyExpires14Days) RenderInto(eml *email) (err error) {
 	eml.subject = helpKeyExpires14DaysSubject
-	eml.htmlBody, err = renderHTML(helpKeyExpires14DaysBodyTemplate, e)
+	eml.textBody, err = renderText(helpKeyExpires14DaysBodyTemplate, e)
 	return err
 }
 

--- a/email/helpkeyexpires.go
+++ b/email/helpkeyexpires.go
@@ -89,7 +89,7 @@ type helpKeyExpires3Days struct {
 func (e helpKeyExpires3Days) ID() string { return "help_key_expires_3_days" }
 func (e helpKeyExpires3Days) RenderInto(eml *email) (err error) {
 	eml.subject = helpKeyExpires3DaysSubject
-	eml.htmlBody, err = render(helpKeyExpires3DaysBodyTemplate, e)
+	eml.htmlBody, err = renderHTML(helpKeyExpires3DaysBodyTemplate, e)
 	return err
 }
 
@@ -137,7 +137,7 @@ type helpKeyExpires7Days struct {
 func (e helpKeyExpires7Days) ID() string { return "help_key_expires_7_days" }
 func (e helpKeyExpires7Days) RenderInto(eml *email) (err error) {
 	eml.subject = helpKeyExpires7DaysSubject
-	eml.htmlBody, err = render(helpKeyExpires7DaysBodyTemplate, e)
+	eml.htmlBody, err = renderHTML(helpKeyExpires7DaysBodyTemplate, e)
 	return err
 }
 
@@ -185,7 +185,7 @@ type helpKeyExpires14Days struct {
 func (e helpKeyExpires14Days) ID() string { return "help_key_expires_14_days" }
 func (e helpKeyExpires14Days) RenderInto(eml *email) (err error) {
 	eml.subject = helpKeyExpires14DaysSubject
-	eml.htmlBody, err = render(helpKeyExpires14DaysBodyTemplate, e)
+	eml.htmlBody, err = renderHTML(helpKeyExpires14DaysBodyTemplate, e)
 	return err
 }
 

--- a/email/render.go
+++ b/email/render.go
@@ -1,0 +1,48 @@
+package email
+
+import (
+	"bytes"
+	htmltemplate "html/template"
+	texttemplate "text/template"
+	"time"
+)
+
+func renderText(templateText string, emailTemplateData interface{}) (string, error) {
+
+	t, err := texttemplate.New("").Parse(templateText)
+
+	if err != nil {
+		return "", err
+	}
+	buf := bytes.NewBuffer(nil)
+	err = t.Execute(buf, emailTemplateData)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func renderHTML(templateText string, emailTemplateData interface{}) (string, error) {
+
+	t, err := htmltemplate.New("").Funcs(funcMap).Parse(templateText)
+
+	if err != nil {
+		return "", err
+	}
+	buf := bytes.NewBuffer(nil)
+	err = t.Execute(buf, emailTemplateData)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// funcMap defines template functions that transform variables into strings in the template
+var funcMap = htmltemplate.FuncMap{
+	"FormatDateTime": func(t time.Time) string {
+		return t.Format("15:04:05 MST on 2 January 2006")
+	},
+	"FormatDate": func(t time.Time) string {
+		return t.Format("2 January 2006")
+	},
+}

--- a/email/sendtestemails.go
+++ b/email/sendtestemails.go
@@ -1,0 +1,63 @@
+package email
+
+import "fmt"
+
+// SendTestEmails sends a plaintext and an HTML email to the given to address.
+func SendTestEmails(to string) error {
+	templates := []emailTemplateInterface{
+		testEmailText{},
+		testEmailHTML{},
+	}
+
+	const (
+		from    = "Fluidkeys <help@mail.fluidkeys.com>"
+		replyTo = "Fluidkeys <help@fluidkeys.com>"
+	)
+
+	for _, template := range templates {
+		email := email{
+			to:      to,
+			from:    from,
+			replyTo: replyTo,
+		}
+
+		err := template.RenderInto(&email)
+		if err != nil {
+			return fmt.Errorf("error rendering email: %v", err)
+		}
+
+		if err := email.send(); err != nil {
+			return fmt.Errorf("error sending mail: %v", err)
+		}
+	}
+	return nil
+}
+
+type testEmailText struct{}
+
+func (e testEmailText) ID() string { return "test_email_text" }
+func (e testEmailText) RenderInto(eml *email) (err error) {
+	eml.subject = "Test email (text)"
+	eml.textBody, err = renderText(testEmailTextBodyTemplate, e)
+	return err
+}
+
+const testEmailTextBodyTemplate = `This is a test email in text format (not HTML)
+
+This should be on a new line.`
+
+type testEmailHTML struct{}
+
+func (e testEmailHTML) ID() string { return "test_email_html" }
+func (e testEmailHTML) RenderInto(eml *email) (err error) {
+	eml.subject = "Test email (HTML)"
+	eml.htmlBody, err = renderHTML(testEmailHTMLBodyTemplate, e)
+	return err
+}
+
+const testEmailHTMLBodyTemplate = `<h1>This is a test email in HTML format</h1>
+
+<p>This should be on a new line.</p>
+
+<b>This should be <b>bold</b></p>
+`

--- a/main.go
+++ b/main.go
@@ -32,6 +32,9 @@ func main() {
 	} else if os.Args[1] == "send_emails" {
 		os.Exit(cmd.SendEmails())
 
+	} else if os.Args[1] == "send_test_emails" {
+		os.Exit(cmd.SendTestEmails())
+
 	} else {
 		fmt.Printf("unrecognised command: `%s`\n", os.Args[1])
 		os.Exit(1)


### PR DESCRIPTION
* add command: send_test_emails <email>
  this allows us to test sending text and HTML emails from production

* email.send: support plain email body

* verify & deleted email: populate `textBody` not `htmlBody`