### PR TITLE
list requests: check I am a team admin

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -14,3 +14,5 @@ var errSignedByWrongKey = fmt.Errorf("signed by wrong key")
 
 // errBadSignature means the signed data may have been tampered with
 var errBadSignature = fmt.Errorf("bad signature")
+
+var errNotAnAdminInExistingTeam = fmt.Errorf("signing key is not an admin of the team")

--- a/server/listrequeststojointeamhandler_test.go
+++ b/server/listrequeststojointeamhandler_test.go
@@ -140,8 +140,6 @@ fingerprint = "BB3C 44BF 188D 56E6 35F4  A092 F73D 2F05 33D7 F9D6"
 	})
 
 	t.Run("for a bad team UUID", func(t *testing.T) {
-		mismatchedFingerprint := exampledata.ExampleFingerprint2
-
 		response := callAPI(
 			t,
 			"GET",
@@ -153,14 +151,9 @@ fingerprint = "BB3C 44BF 188D 56E6 35F4  A092 F73D 2F05 33D7 F9D6"
 		assertStatusCode(t, http.StatusBadRequest, response.Code)
 		assertHasJSONErrorDetail(t, response.Body,
 			"uuid: incorrect UUID length: foo")
-
-		_, err := datastore.DeletePublicKey(mismatchedFingerprint)
-		assert.NoError(t, err)
 	})
 
 	t.Run("for a team that doesn't exist", func(t *testing.T) {
-		mismatchedFingerprint := exampledata.ExampleFingerprint2
-
 		response := callAPI(
 			t,
 			"GET",
@@ -172,9 +165,6 @@ fingerprint = "BB3C 44BF 188D 56E6 35F4  A092 F73D 2F05 33D7 F9D6"
 		assertStatusCode(t, http.StatusNotFound, response.Code)
 		assertHasJSONErrorDetail(t, response.Body,
 			"team not found")
-
-		_, err := datastore.DeletePublicKey(mismatchedFingerprint)
-		assert.NoError(t, err)
 	})
 
 }

--- a/server/teamshandler.go
+++ b/server/teamshandler.go
@@ -358,7 +358,3 @@ func deleteRequestToJoinTeamHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 	w.Write(nil)
 }
-
-var (
-	errNotAnAdminInExistingTeam = fmt.Errorf("signing key is not an admin of the team")
-)


### PR DESCRIPTION
previously, the list requests endpoint checked whether *I had signed the
roster*. That's no good because it only allows for one admin!

Instead, check whether I'm an admin of the team.

Fixes https://trello.com/c/9cF2ajFW