### PR TITLE
`make test`: don't run tests verbosely

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ migrate:
 
 .PHONY: test
 test:
-	go test -v -failfast ./...
+	go test -failfast ./...
 	find . -name '*.go' -not -path './vendor/*' -exec golint {} \;
 
 .PHONY: jenkins_deploy_to_heroku


### PR DESCRIPTION
it makes it really hard to see which test failed, as the failure gets
followed by loads more test output