### PR TITLE
support "version" field in team endpoint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,7 +27,7 @@
   revision = "d1eb919c5d7a79d47db3bed84c8637648a60ab27"
 
 [[projects]]
-  digest = "1:a35a1bb8f243b75e2056797c8581e0dd10440930851a4a001f365ca7671fa394"
+  digest = "1:02d78462f679746d02d4d8421f4904c6a7e8a28228dc075047cb2f5fbaafffd9"
   name = "github.com/fluidkeys/fluidkeys"
   packages = [
     "assert",
@@ -42,7 +42,7 @@
     "team",
   ]
   pruneopts = "UT"
-  revision = "8caab409b98a09b6a15183791f13631d95572025"
+  revision = "08541d161b0b529bffaa910c7f0ee44779ca8c63"
 
 [[projects]]
   digest = "1:c594a691090b434d55c67f6cc8e326ef5ba49452abc059821bd5d4fd4cdef08c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -41,4 +41,4 @@
   name = "github.com/fluidkeys/fluidkeys"
 
   # run `dep ensure` after editing this to updte vendor
-  revision = "8caab409b98a09b6a15183791f13631d95572025"
+  revision = "08541d161b0b529bffaa910c7f0ee44779ca8c63"

--- a/vendor/github.com/fluidkeys/fluidkeys/policy/policy.go
+++ b/vendor/github.com/fluidkeys/fluidkeys/policy/policy.go
@@ -155,29 +155,18 @@ const (
 )
 
 // NextExpiryTime returns the expiry time in UTC, according to the policy:
-//     "30 days after the 1st of the next month"
-// for example, if today is 15th September, nextExpiryTime would return
-// 1st October + 30 days
+//     "1 year from now, rounded forward to the 1st of the next Feb, May, Aug or Nov
+// for example, if today is 15th September 2018, nextExpiryTime would return
+// 1st November 2019
 func NextExpiryTime(now time.Time) time.Time {
-	return firstOfNextMonth(now).Add(thirtyDays).In(time.UTC)
+	oneYearFromNow := now.In(time.UTC).Add(oneYear)
+	return followingQuarter(oneYearFromNow)
 }
 
-// NextRotation returns 30 days before the earliest expiry time on
-// the key.
+// NextRotation returns 60 days before the earliest expiry time on the key.
 // If the key doesn't expire, it returns nil.
 func NextRotation(expiry time.Time) time.Time {
-	return expiry.Add(-thirtyDays)
-}
-
-// IsExpiryTooLong returns true if the expiry is too far in the future.
-//
-// It's important not to raise this warning for expiries that we've set
-// ourselves.
-// We use `NextExpiryTime` such that when we set an expiry date it's *exactly*
-// on the cusp of being too long, and can only get shorter after that point.
-func IsExpiryTooLong(expiry time.Time, now time.Time) bool {
-	latestAcceptableExpiry := NextExpiryTime(now)
-	return expiry.After(latestAcceptableExpiry)
+	return expiry.Add(-sixtyDays)
 }
 
 // IsOverdueForRotation returns true if `now` is more than 10 days after
@@ -193,9 +182,29 @@ func IsDueForRotation(nextRotation time.Time, now time.Time) bool {
 	return nextRotation.Before(now)
 }
 
-func firstOfNextMonth(today time.Time) time.Time {
-	firstOfThisMonth := beginningOfMonth(today)
-	return beginningOfMonth(firstOfThisMonth.Add(fortyFiveDays))
+func followingQuarter(from time.Time) time.Time {
+	lookup := map[time.Month]int{
+		time.January:   1,
+		time.February:  3,
+		time.March:     2,
+		time.April:     1,
+		time.May:       3,
+		time.June:      2,
+		time.July:      1,
+		time.August:    3,
+		time.September: 2,
+		time.October:   1,
+		time.November:  3,
+		time.December:  2,
+	}
+
+	firstOfThisMonth := beginningOfMonth(from.In(time.UTC))
+	monthsToAdvance, _ := lookup[firstOfThisMonth.Month()]
+	daysToAdvance := (30 * monthsToAdvance) + 15
+
+	return beginningOfMonth(
+		firstOfThisMonth.Add(time.Duration(24*daysToAdvance) * time.Hour),
+	)
 }
 
 func beginningOfMonth(now time.Time) time.Time {
@@ -207,4 +216,6 @@ const (
 	tenDays       time.Duration = time.Duration(time.Hour * 24 * 10)
 	thirtyDays    time.Duration = time.Duration(time.Hour * 24 * 30)
 	fortyFiveDays time.Duration = time.Duration(time.Hour * 24 * 45)
+	sixtyDays     time.Duration = time.Duration(time.Hour * 24 * 60)
+	oneYear       time.Duration = time.Duration(time.Hour * 24 * 365)
 )

--- a/vendor/github.com/fluidkeys/fluidkeys/team/validateupdate.go
+++ b/vendor/github.com/fluidkeys/fluidkeys/team/validateupdate.go
@@ -1,0 +1,95 @@
+package team
+
+import "fmt"
+
+// ValidateUpdate tests whether the given changes to a team are OK
+func ValidateUpdate(before *Team, after *Team, me *Person) error {
+	// validate the team UUID didn't change
+	// team name can't change
+	// can't change the email for a given key
+	// how to handle email address changes? deny them?
+	// don't allow people to be arbitrarily added (I think)
+	// email address appears twice
+	// fingerprint appears twice
+	// I can't remove myself from a team
+	// I can't demote myself as an admin (another admin must promote)
+	// factor out before/after tests from API?
+	// validate that there's still a team admin
+	// protect against replay attacks: prevent someone from uploading an old (signed) version of the file
+	// signing key's fingerprint missing from roster
+	// signing key isn't listed in roster
+	// signing key listed in roster but not an admin
+
+	if err := after.Validate(); err != nil {
+		return err
+	}
+
+	if err := validateTeamUUID(before, after); err != nil {
+		return err
+	}
+
+	if err := validateTeamNameCantChange(before, after); err != nil {
+		return err
+	}
+
+	if err := validateVersionMustIncrementByOne(before, after); err != nil {
+		return err
+	}
+
+	if err := validateIAmAdmin(before, after, me); err != nil {
+		return err
+	}
+
+	if err := validateCannotRemoveSelf(before, after, me); err != nil {
+		return err
+	}
+
+	if err := validateCannotDemoteSelfAsAdmin(before, after, me); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateTeamUUID(before, after *Team) error {
+	if before.UUID != after.UUID {
+		return fmt.Errorf("team UUID cannot be changed")
+	}
+	return nil
+}
+
+func validateTeamNameCantChange(before, after *Team) error {
+	if before.Name != after.Name {
+		return fmt.Errorf("team name cannot currently be changed")
+	}
+	return nil
+}
+
+func validateVersionMustIncrementByOne(before, after *Team) error {
+	if after.Version != before.Version+1 {
+		return fmt.Errorf("invalid version number v%d (expected v%d)",
+			after.Version, before.Version+1)
+	}
+	return nil
+}
+
+func validateIAmAdmin(before, after *Team, me *Person) error {
+	if !before.IsAdmin(me.Fingerprint) {
+		return fmt.Errorf("you're not a team admin")
+	}
+	return nil
+}
+
+func validateCannotRemoveSelf(before, after *Team, me *Person) error {
+	if !after.Contains(me.Fingerprint) {
+		return fmt.Errorf("can't remove yourself from the team")
+	}
+	return nil
+}
+
+func validateCannotDemoteSelfAsAdmin(before, after *Team, me *Person) error {
+	if !after.IsAdmin(me.Fingerprint) {
+		return fmt.Errorf("can't demote yourself as team admin")
+	}
+	return nil
+}


### PR DESCRIPTION
* bump `fluidkeys/fluidkeys` dependency to get version of `Team` struct which includes `Version`

* tests: ensure with / without version is OK. this is to ensure the endpoint can accept rosters with the new `version` field *and* rosters where the field is missing (older versions of `fk`)

It *should* be OK to merge and deploy this without breaking old versions of `fk` that don't send a `version`. (This would be an excellent thing to verify!)